### PR TITLE
[CMS-799] Deprecate pantheon-cache command

### DIFF
--- a/inc/cli.php
+++ b/inc/cli.php
@@ -15,10 +15,32 @@ WP_CLI::add_command( 'pantheon-cache', '\\Pantheon\\CLI\\__deprecated_maintenanc
 WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**
- * Returns a deprecation notice for the pantheon-cache command.
+ * Sets maintenance mode status.
  *
- * The `pantheon-cache` command and `set-maintenance-mode` subcommand is
- * deprecated. Use `wp pantheon set-maintenance-mode` instead.
+ * Enable maintenance mode to work on your site while serving cached pages
+ * to visitors and bots, or everyone except administators.
+ *
+ * ## DEPRECATION NOTICE
+ *
+ * This command is deprecated. Use `pantheon set-maintenance-mode` instead.
+ *
+ * ## USAGE
+ *
+ * wp pantheon-cache set-maintenance-mode <status> (deprecated) or
+ * wp pantheon set-maintenance-mode <status>
+ *
+ * ## OPTIONS
+ *
+ * <status>
+ * : Maintenance mode status.
+ * ---
+ * options:
+ *   - disabled
+ *   - anonymous
+ *   - everyone
+ * ---
+ *
+ * @subcommand set-maintenance-mode
  *
  * @deprecated 1.0.0
  */

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -13,6 +13,7 @@ use WP_CLI;
 // Support the old pantheon-cache command but return a deprecation notice.
 WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
 WP_CLI::add_command( 'pantheon cache set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
+WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**
  * Sets maintenance mode status.

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -12,7 +12,7 @@ use WP_CLI;
 
 // Support the old pantheon-cache command but return a deprecation notice.
 WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
-WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
+WP_CLI::add_command( 'pantheon cache set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**
  * Sets maintenance mode status.

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -28,7 +28,7 @@ WP_CLI::add_command( 'pantheon cache set-maintenance-mode', '\\Pantheon\\CLI\\se
  * ## USAGE
  *
  * wp pantheon-cache set-maintenance-mode <status> (deprecated) or
- * wp pantheon set-maintenance-mode <status>
+ * wp pantheon cache set-maintenance-mode <status>
  *
  * ## OPTIONS
  *

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * WP-CLI commands for the Pantheon mu-plugin.
+ *
+ * @package pantheon
+ */
+
+namespace Pantheon\CLI;

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -15,7 +15,10 @@ WP_CLI::add_command( 'pantheon-cache', '\\Pantheon\\CLI\\__deprecated_maintenanc
 WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**
- * Returns a deprecated notice for the pantheon-cache command.
+ * Returns a deprecation notice for the pantheon-cache command.
+ *
+ * The `pantheon-cache` command and `set-maintenance-mode` subcommand is
+ * deprecated. Use `wp pantheon set-maintenance-mode` instead.
  *
  * @deprecated 1.0.0
  */

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -11,7 +11,7 @@ use Pantheon_Cache;
 use WP_CLI;
 
 // Support the old pantheon-cache command but return a deprecation notice.
-WP_CLI::add_command( 'pantheon-cache', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
+WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
 WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -45,7 +45,8 @@ WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_main
  * @deprecated 1.0.0
  */
 function __deprecated_maintenance_mode_output( $args ) {
-	$replacement_command = ( ! empty( $args ) && in_array( 'set-maintenance-mode', $args, true ) ) ? 'set-maintenance-mode' : '<command>';
+	$allowed_args = [ 'disabled', 'anonymous', 'everyone' ];
+	$replacement_command = ( ! empty( $args  && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
 
 	WP_CLI::warning( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
 

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -25,7 +25,9 @@ WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_main
 function __deprecated_maintenance_mode_output( $args ) {
 	$replacement_command = ( ! empty( $args ) && in_array( 'set-maintenance-mode', $args, true ) ) ? 'set-maintenance-mode' : '<command>';
 
-	WP_CLI::error( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
+	WP_CLI::warning( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
+
+	set_maintenance_mode_command( $args );
 }
 
 /**

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -48,7 +48,8 @@ function __deprecated_maintenance_mode_output( $args ) {
 	$allowed_args = [ 'disabled', 'anonymous', 'everyone' ];
 	$replacement_command = ( ! empty( $args  && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
 
-	WP_CLI::warning( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
+	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
+	WP_CLI::line( __( 'Run `wp pantheon set-maintenance-mode --help` for more information.', 'pantheon-systems' ) );
 
 	set_maintenance_mode_command( $args );
 }

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -6,3 +6,7 @@
  */
 
 namespace Pantheon\CLI;
+
+use Pantheon_Cache;
+use WP_CLI;
+WP_CLI::add_command( 'pantheon set-maintenance-mode', [ Pantheon_Cache::instance(), 'set_maintenance_mode_command' ] );

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -51,6 +51,11 @@ function __deprecated_maintenance_mode_output( $args ) {
 	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
 	WP_CLI::line( __( 'Run `wp pantheon set-maintenance-mode --help` for more information.', 'pantheon-systems' ) );
 
+	// The command should fail before we get here, but in case it doesn't, display an error.
+	if ( false === $replacement_command ) {
+		WP_CLI::error( __( 'Invalid arguments. Run `wp pantheon set-maintenance-mode --help` for more infomation.', 'pantheon-systems' ) );
+	}
+
 	set_maintenance_mode_command( $args );
 }
 

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -22,7 +22,8 @@ WP_CLI::add_command( 'pantheon cache set-maintenance-mode', '\\Pantheon\\CLI\\se
  *
  * ## DEPRECATION NOTICE
  *
- * This command is deprecated. Use `pantheon set-maintenance-mode` instead.
+ * This command is deprecated and will be removed in a future release.
+ * Use `pantheon set-maintenance-mode` instead.
  *
  * ## USAGE
  *
@@ -48,7 +49,7 @@ function __deprecated_maintenance_mode_output( $args ) {
 	$allowed_args = [ 'disabled', 'anonymous', 'everyone' ];
 	$replacement_command = ( ! empty( $args  && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
 
-	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
+	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated and will be removed in a future release. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
 	WP_CLI::line( __( 'Run `wp pantheon set-maintenance-mode --help` for more information.', 'pantheon-systems' ) );
 
 	// The command should fail before we get here, but in case it doesn't, display an error.

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -9,4 +9,18 @@ namespace Pantheon\CLI;
 
 use Pantheon_Cache;
 use WP_CLI;
+
+// Support the old pantheon-cache command but return a deprecation notice.
+WP_CLI::add_command( 'pantheon-cache', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
 WP_CLI::add_command( 'pantheon set-maintenance-mode', [ Pantheon_Cache::instance(), 'set_maintenance_mode_command' ] );
+
+/**
+ * Returns a deprecated notice for the pantheon-cache command.
+ *
+ * @deprecated 1.0.0
+ */
+function __deprecated_maintenance_mode_output( $args ) {
+	$replacement_command = ( ! empty( $args ) && in_array( 'set-maintenance-mode', $args, true ) ) ? 'set-maintenance-mode' : '<command>';
+
+	WP_CLI::error( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
+}

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -12,7 +12,7 @@ use WP_CLI;
 
 // Support the old pantheon-cache command but return a deprecation notice.
 WP_CLI::add_command( 'pantheon-cache', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
-WP_CLI::add_command( 'pantheon set-maintenance-mode', [ Pantheon_Cache::instance(), 'set_maintenance_mode_command' ] );
+WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
 
 /**
  * Returns a deprecated notice for the pantheon-cache command.
@@ -23,4 +23,38 @@ function __deprecated_maintenance_mode_output( $args ) {
 	$replacement_command = ( ! empty( $args ) && in_array( 'set-maintenance-mode', $args, true ) ) ? 'set-maintenance-mode' : '<command>';
 
 	WP_CLI::error( sprintf( __( 'This command is deprecated. Use `wp pantheon %s` instead. Run `wp pantheon --help` for more infomation.', 'pantheon-systems' ), $replacement_command ) );
+}
+
+/**
+ * Sets maintenance mode status.
+ *
+ * Enable maintenance mode to work on your site while serving cached pages
+ * to visitors and bots, or everyone except administators.
+ *
+ * ## OPTIONS
+ *
+ * <status>
+ * : Maintenance mode status.
+ * ---
+ * options:
+ *   - disabled
+ *   - anonymous
+ *   - everyone
+ * ---
+ *
+ * @subcommand set-maintenance-mode
+ */
+function set_maintenance_mode_command( $args ) {
+
+	list( $status ) = $args;
+
+	$out = Pantheon_Cache()->default_options;
+	if ( ! empty( $status )
+		&& in_array( $status, [ 'anonymous', 'everyone' ], true ) ) {
+		$out['maintenance_mode'] = $status;
+	} else {
+		$out['maintenance_mode'] = 'disabled';
+	}
+	update_option( Pantheon_Cache::SLUG, $out );
+	WP_CLI::success( sprintf( 'Maintenance mode set to: %s', $out['maintenance_mode'] ) );
 }

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -548,11 +548,6 @@ function Pantheon_Cache() {
 }
 add_action( 'plugins_loaded', 'Pantheon_Cache' );
 
-
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', [ Pantheon_Cache::instance(), 'set_maintenance_mode_command' ] );
-}
-
 /**
  * @see Pantheon_Cache::clean_post_cache
  *

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -498,40 +498,6 @@ class Pantheon_Cache {
 			pantheon_clear_edge_paths( $this->paths );
 		}
 	}
-
-	/**
-	 * Sets maintenance mode status.
-	 *
-	 * Enable maintenance mode to work on your site while serving cached pages
-	 * to visitors and bots, or everyone except administators.
-	 *
-	 * ## OPTIONS
-	 *
-	 * <status>
-	 * : Maintenance mode status.
-	 * ---
-	 * options:
-	 *   - disabled
-	 *   - anonymous
-	 *   - everyone
-	 * ---
-	 *
-	 * @subcommand set-maintenance-mode
-	 */
-	public function set_maintenance_mode_command( $args ) {
-
-		list( $status ) = $args;
-
-		$out = $this->default_options;
-		if ( ! empty( $status )
-			&& in_array( $status, [ 'anonymous', 'everyone' ], true ) ) {
-			$out['maintenance_mode'] = $status;
-		} else {
-			$out['maintenance_mode'] = 'disabled';
-		}
-		update_option( self::SLUG, $out );
-		WP_CLI::success( sprintf( 'Maintenance mode set to: %s', $out['maintenance_mode'] ) );
-	}
 }
 
 

--- a/pantheon.php
+++ b/pantheon.php
@@ -22,6 +22,9 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( 'dev' === $_ENV['PANTHEON_ENVIRONMENT'] && function_exists( 'wp_is_writable' ) ) {
 		require_once 'inc/pantheon-plugin-install-notice.php';
 	}
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        require_once 'inc/cli.php';
+    }
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
 		 * When this constant is not set, WordPress writes and then deletes a

--- a/pantheon.php
+++ b/pantheon.php
@@ -24,12 +24,12 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	}
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
-		 * When this constant is not set, WordPress writes and then deletes a 
+		 * When this constant is not set, WordPress writes and then deletes a
 		 * temporary file to determine if it has direct access to the filesystem,
-		 * which we already know to be the case.  This multiplies filesystem 
+		 * which we already know to be the case.  This multiplies filesystem
 		 * operations and can degrade performance of the filesystem as a whole in
-		 * the case of large sites that do a lot of filesystem operations.  
-		 * Setting this constant to 'direct' tells WordPress to assume it has 
+		 * the case of large sites that do a lot of filesystem operations.
+		 * Setting this constant to 'direct' tells WordPress to assume it has
 		 * direct access and skip creating the extra temporary file.
 		 */
 		define( 'FS_METHOD', 'direct' );


### PR DESCRIPTION
This PR is to deprecate the `pantheon-cache` command in favor of using `pantheon cache` as the top level WP-CLI command.

* adds a new `cli.php` file for all WP-CLI commands to add to the `mu-plugin`
* moves `pantheon-cache set-maintenance-mode` command to `cli.php`
* renames `pantheon-cache set-maintenance-mode` to `pantheon set-maintenance-mode`
* adds deprecated command for `pantheon-cache` which ~returns an error~ displays a notice about the updated command to use for `set-maintenance-mode` and runs the command

**Note:** Until CMS-791 is addressed, this will need to be replicated in pantheon-systems/WordPress. 

**Also note:** The help message for `wp pantheon-cache` is autogenerated. As best as I can tell, it can't be modified. It's derived from the command that was added: `wp pantheon-cache set-maintenance-mode` automatically. However, when the command is run, and when the help function is run against the full subcommand (`wp pantheon-cache set-maintenance-mode --help`), deprecation notices are shown as illustrated in the Loom.

https://www.loom.com/share/565498af62b940c08d38bced3af6e8c7

Updated Loom showing the same command using `wp pantheon cache`
https://www.loom.com/share/b74d3e9602af4fd8b618418e48276311