### PR TITLE
[BUGS-6017] Update the WP update messaging for development versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore composer files.
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,9 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "scripts": {
+    "lint": "vendor/bin/phpcs -s --standard=Pantheon-WP .",
+    "lint:cbf": "vendor/bin/phpcbf -s --standard=Pantheon-WP ."
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,13 @@
   "license": "MIT",
   "require": {
     "vlucas/phpdotenv": "*"
+  },
+  "require-dev": {
+    "pantheon-systems/pantheon-wp-coding-standards": "^1.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -18,7 +18,7 @@ function _pantheon_hide_update_nag() {
 
 // Get the latest WordPress version
 function _pantheon_get_latest_wordpress_version() {
-	$core_updates = get_core_updates( array('dismissed' => false) );
+	$core_updates = get_core_updates();
 
 	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
 		return null;
@@ -27,8 +27,12 @@ function _pantheon_get_latest_wordpress_version() {
 	return $core_updates[0]->current;
 }
 
-// Check if WordPress core is at the latest version.
-function _pantheon_is_wordpress_core_latest() {
+/**
+ * Check if WordPress core is at the latest version.
+ *
+ * @return bool
+ */
+function _pantheon_is_wordpress_core_latest() : bool {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
 
 	if( null === $latest_wp_version ){
@@ -39,9 +43,11 @@ function _pantheon_is_wordpress_core_latest() {
 	include( ABSPATH . WPINC . '/version.php' );
 
 	// Return true if our version is the latest
-	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '=' );
+	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' );
 
 }
+
+
 
 // Replace WordPress core update nag EVERYWHERE with our own notice (use git upstream)
 function _pantheon_upstream_update_notice() {
@@ -56,7 +62,7 @@ function _pantheon_upstream_update_notice() {
 
 	if ( _pantheon_is_wordpress_core_latest() ) {
 		// If a WP core update is not detected, only show the nag on the updates page.
-		$screen = get_current_screen(); 
+		$screen = get_current_screen();
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) { ?>
 			<div class="<?php echo $div_class; ?>" style="<?php echo $div_style; ?>">
 				<p style="<?php echo $paragraph_style; ?>">

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -174,7 +174,7 @@ function _pantheon_disable_wp_updates() : object {
 
 // In the Test and Live environments, clear plugin/theme update notifications.
 // Users must check a dev or multidev environment for updates.
-if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ], true ) && ( php_sapi_name() !== 'cli' ) ) {
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ], true ) && ( php_sapi_name() !== 'cli' ) ) {
 
 	// Disable Plugin Updates.
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -63,6 +63,19 @@ function _pantheon_is_wordpress_core_latest() : bool {
 }
 
 /**
+ * Check if WordPress core is a pre-release version.
+ *
+ * @return bool
+ */
+function _pantheon_is_wordpress_core_prerelease() : bool {
+	// include an unmodified $wp_version.
+	include ABSPATH . WPINC . '/version.php';
+
+	// Return true if our version is a prerelease. Pre-releases are identified by a dash in the version number.
+	return false !== strpos( $wp_version, '-' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+}
+
+/**
  * Replace WordPress core update nag EVERYWHERE with our own notice.
  * Use git upstream instead
  *

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -17,6 +17,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	add_action( 'admin_menu', '_pantheon_hide_update_nag' );
 }
 
+/**
+ * Remove the default WordPress core update nag message.
+ *
+ * @return void
+ */
 function _pantheon_hide_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
@@ -111,8 +116,7 @@ function _pantheon_upstream_update_notice() {
  * @return void
  */
 function _pantheon_register_upstream_update_notice() {
-	// but only if we are on Pantheon
-	// and this is not a WordPress Ajax request
+	// Only register notice if we are on Pantheon and this is not a WordPress Ajax request.
 	if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && ! wp_doing_ajax() ) {
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 		add_action( 'network_admin_notices', '_pantheon_upstream_update_notice' );
@@ -138,11 +142,11 @@ function _pantheon_disable_wp_updates() : object {
 // Users must check a dev or multidev environment for updates.
 if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ] ) && ( php_sapi_name() !== 'cli' ) ) {
 
-	// Disable Plugin Updates
+	// Disable Plugin Updates.
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );
 	add_filter( 'pre_site_transient_update_plugins', '_pantheon_disable_wp_updates' );
 
-	// Disable Theme Updates
+	// Disable Theme Updates.
 	remove_action( 'load-update-core.php', 'wp_update_themes' );
 	add_filter( 'pre_site_transient_update_themes', '_pantheon_disable_wp_updates' );
 }

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -82,6 +82,7 @@ function _pantheon_is_wordpress_core_prerelease() : bool {
  * @return void
  */
 function _pantheon_upstream_update_notice() {
+	$version = _pantheon_get_latest_wordpress_version();
 	$screen = get_current_screen();
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
 	$notice_message = sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
@@ -98,9 +99,11 @@ function _pantheon_upstream_update_notice() {
 		$notice_message = sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
 	}
 
+	// If WP core is a pre-release, alter the message.
 	if ( _pantheon_is_wordpress_core_prerelease() ) {
-		// If WP core is a pre-release, alter the message.
-		$notice_message = __( 'You are using a development version of WordPress.', 'pantheon-systems' );
+		$version_message = $version ?: '<span style="font-weight: normal;">(' . $version . ')</span>';
+		// Translators: %s is the current WordPress version.
+		$notice_message = sprintf( __( 'You are using a development version of WordPress. %s', 'pantheon-systems' ), $version_message );
 		// If we're on the Updates page, add a note about the Beta Tester plugin.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			$notice_message .= '<br /><span style="font-weight: normal;">';

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -134,11 +134,7 @@ function _pantheon_upstream_update_notice() {
 	<?php
 	$notice_html = ob_get_clean();
 	// If a WP core update is not detected, only show the nag on the updates page.
-	if (
-		! _pantheon_is_wordpress_core_latest() || (
-			_pantheon_is_wordpress_core_latest() &&
-			( 'update-core' === $screen->id || 'update-core-network' === $screen->id )
-		) ) {
+	if ( ! _pantheon_is_wordpress_core_latest() || 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			// Escaping is handled above when we're buffering the output, so we can ignore it here.
 			echo $notice_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -28,6 +28,16 @@ function _pantheon_hide_update_nag() {
 }
 
 /**
+ * Helper function that returns the current WordPress version.
+ *
+ * @return string
+ */
+function _pantheon_get_current_wordpress_version() : string {
+	include ABSPATH . WPINC . '/version.php';
+	return $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+}
+
+/**
  * Get the latest WordPress version.
  *
  * @return string|null
@@ -49,13 +59,11 @@ function _pantheon_get_latest_wordpress_version() : ?string {
  */
 function _pantheon_is_wordpress_core_latest() : bool {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+	$wp_version = _pantheon_get_current_wordpress_version();
 
 	if ( null === $latest_wp_version ) {
 		return true;
 	}
-
-	// include an unmodified $wp_version.
-	include ABSPATH . WPINC . '/version.php';
 
 	// Return true if our version is the latest.
 	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
@@ -68,8 +76,7 @@ function _pantheon_is_wordpress_core_latest() : bool {
  * @return bool
  */
 function _pantheon_is_wordpress_core_prerelease() : bool {
-	// include an unmodified $wp_version.
-	include ABSPATH . WPINC . '/version.php';
+	$wp_version = _pantheon_get_current_wordpress_version();
 
 	// Return true if our version is a prerelease. Pre-releases are identified by a dash in the version number.
 	return false !== strpos( $wp_version, '-' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
@@ -82,7 +89,7 @@ function _pantheon_is_wordpress_core_prerelease() : bool {
  * @return void
  */
 function _pantheon_upstream_update_notice() {
-	$version = _pantheon_get_latest_wordpress_version();
+	$wp_version = _pantheon_get_current_wordpress_version();
 	$screen = get_current_screen();
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
 	$notice_message = sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
@@ -156,7 +163,7 @@ add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
  * @return object
  */
 function _pantheon_disable_wp_updates() : object {
-	include ABSPATH . WPINC . '/version.php';
+	$wp_version = _pantheon_get_current_wordpress_version();
 	return (object) [
 		'updates' => [],
 		'version_checked' => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -133,14 +133,14 @@ function _pantheon_upstream_update_notice() {
 	</div>
 	<?php
 	$notice_html = ob_get_clean();
-	if ( _pantheon_is_wordpress_core_latest() ) {
-		// If a WP core update is not detected, only show the nag on the updates page.
-		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
+	// If a WP core update is not detected, only show the nag on the updates page.
+	if (
+		! _pantheon_is_wordpress_core_latest() || (
+			_pantheon_is_wordpress_core_latest() &&
+			( 'update-core' === $screen->id || 'update-core-network' === $screen->id )
+		) ) {
 			// Escaping is handled above when we're buffering the output, so we can ignore it here.
 			echo $notice_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
-	} else {
-		echo $notice_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -58,7 +58,7 @@ function _pantheon_is_wordpress_core_latest() : bool {
 	include ABSPATH . WPINC . '/version.php';
 
 	// Return true if our version is the latest.
-	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' );
+	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 }
 
@@ -133,7 +133,7 @@ function _pantheon_disable_wp_updates() : object {
 	include ABSPATH . WPINC . '/version.php';
 	return (object) [
 		'updates' => [],
-		'version_checked' => $wp_version,
+		'version_checked' => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 		'last_checked' => time(),
 	];
 }

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -108,9 +108,9 @@ function _pantheon_upstream_update_notice() {
 
 	// If WP core is a pre-release, alter the message.
 	if ( _pantheon_is_wordpress_core_prerelease() ) {
-		$version_message = $version ?: '<span style="font-weight: normal;">(' . $version . ')</span>';
+		$version = '<span style="font-weight: normal;">(' . $wp_version . ')</span>';
 		// Translators: %s is the current WordPress version.
-		$notice_message = sprintf( __( 'You are using a development version of WordPress. %s', 'pantheon-systems' ), $version_message );
+		$notice_message = sprintf( __( 'You are using a development version of WordPress. %s', 'pantheon-systems' ), $version );
 		// If we're on the Updates page, add a note about the Beta Tester plugin.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			$notice_message .= '<br /><span style="font-weight: normal;">';

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -140,7 +140,7 @@ function _pantheon_disable_wp_updates() : object {
 
 // In the Test and Live environments, clear plugin/theme update notifications.
 // Users must check a dev or multidev environment for updates.
-if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ] ) && ( php_sapi_name() !== 'cli' ) ) {
+if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ], true ) && ( php_sapi_name() !== 'cli' ) ) {
 
 	// Disable Plugin Updates.
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -1,13 +1,19 @@
 <?php
-// If on Pantheon
+/**
+ * Pantheon MU Plugin Updates
+ *
+ * Handles modifying the default WordPress update behavior on Pantheon.
+ */
+
+// If on Pantheon...
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
-	// Disable WordPress auto updates
+	// Disable WordPress auto updates.
 	if ( ! defined( 'WP_AUTO_UPDATE_CORE' ) ) {
 		define( 'WP_AUTO_UPDATE_CORE', false );
 	}
 
 	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
-	// Remove the default WordPress core update nag
+	// Remove the default WordPress core update nag.
 	add_action( 'admin_menu', '_pantheon_hide_update_nag' );
 }
 
@@ -17,7 +23,7 @@ function _pantheon_hide_update_nag() {
 }
 
 /**
- * Get the latest WordPress version
+ * Get the latest WordPress version.
  *
  * @return string|null
  */
@@ -43,17 +49,17 @@ function _pantheon_is_wordpress_core_latest() : bool {
 		return true;
 	}
 
-	// include an unmodified $wp_version
+	// include an unmodified $wp_version.
 	include ABSPATH . WPINC . '/version.php';
 
-	// Return true if our version is the latest
+	// Return true if our version is the latest.
 	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' );
 
 }
 
 /**
- * Replace WordPress core update nag EVERYWHERE with our own notice
- * (use git upstream)
+ * Replace WordPress core update nag EVERYWHERE with our own notice.
+ * Use git upstream instead
  *
  * @return void
  */
@@ -100,7 +106,7 @@ function _pantheon_upstream_update_notice() {
 }
 
 /**
- * Register Pantheon specific WordPress update admin notice
+ * Register Pantheon specific WordPress update admin notice.
  *
  * @return void
  */
@@ -115,7 +121,7 @@ function _pantheon_register_upstream_update_notice() {
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
 
 /**
- * Return zero updates and current time as last checked time
+ * Return zero updates and current time as last checked time.
  *
  * @return object
  */

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -70,10 +70,10 @@ function _pantheon_is_wordpress_core_latest() : bool {
  */
 function _pantheon_upstream_update_notice() {
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
-	$notice_message = wp_kses_post( sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );
+	$notice_message = sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
 	// Translators: %s is a URL to Pantheon's upstream updates documentation.
-	$upstream_help_message = wp_kses_post( sprintf( __( 'For details on applying updates, see the <a href="%s">Applying Upstream Updates</a> documentation.', 'pantheon-systems' ), 'https://docs.pantheon.io/core-updates' ) );
-	$update_help = wp_kses_post( __( 'If you need help, contact an administrator for your Pantheon organization.', 'pantheon-systems' ) );
+	$upstream_help_message = sprintf( __( 'For details on applying updates, see the <a href="%s">Applying Upstream Updates</a> documentation.', 'pantheon-systems' ), 'https://docs.pantheon.io/core-updates' );
+	$update_help = __( 'If you need help, contact an administrator for your Pantheon organization.', 'pantheon-systems' );
 	$div_class = esc_attr( 'update-nag notice notice-warning' );
 	$div_style = esc_attr( 'display: table;' );
 	$paragraph_style = esc_attr( 'font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;' );
@@ -82,29 +82,29 @@ function _pantheon_upstream_update_notice() {
 		// If a WP core update is not detected, only show the nag on the updates page.
 		$screen = get_current_screen();
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) { ?>
-			<div class="<?php echo $div_class; ?>" style="<?php echo $div_style; ?>">
-				<p style="<?php echo $paragraph_style; ?>">
-					<?php echo $notice_message; ?>
+			<div class="<?php echo esc_attr( $div_class ); ?>" style="<?php echo esc_attr( $div_style ); ?>">
+				<p style="<?php echo esc_attr( $paragraph_style ); ?>">
+					<?php echo wp_kses_post( $notice_message ); ?>
 				</p>
-				<?php echo $upstream_help_message; ?>
+				<?php echo wp_kses_post( $upstream_help_message ); ?>
 				<br />
-				<?php echo $update_help; ?>
+				<?php echo wp_kses_post( $update_help ); ?>
 			</div>
 			<?php
 		}
 	} else {
 		// If WP core is out of date, alter the message and show the nag everywhere.
 		// Translators: %s is a URL to the user's Pantheon Dashboard.
-		$notice_message = wp_kses_post( sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );
+		$notice_message = sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
 
 		?>
-		<div class="<?php echo $div_class; ?>" style="<?php echo $div_style; ?>">
-			<p style="<?php echo $paragraph_style; ?>">
-				<?php echo $notice_message; ?>
+		<div class="<?php echo esc_attr( $div_class ); ?>" style="<?php echo esc_attr( $div_style ); ?>">
+			<p style="<?php echo esc_attr( $paragraph_style ); ?>">
+				<?php echo wp_kses_post( $notice_message ); ?>
 			</p>
-			<?php echo $upstream_help_message; ?>
+			<?php echo wp_kses_post( $upstream_help_message ); ?>
 			<br />
-			<?php echo $update_help; ?>
+			<?php echo wp_kses_post( $update_help ); ?>
 		</div>
 		<?php
 	}

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -104,7 +104,7 @@ function _pantheon_upstream_update_notice() {
 		// If we're on the Updates page, add a note about the Beta Tester plugin.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			$notice_message .= '<br /><span style="font-weight: normal;">';
-			$notice_message .= __( 'You are responsible for keeping WordPress up-to-date. Pantheon updates to WordPress will not appear in the dashboard as long as you\'re using a development version. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' );
+			$notice_message .= __( 'You are responsible for keeping WordPress up-to-date. Pantheon updates to WordPress will not appear in the dashboard as long as you\'re using a pre-release version. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' );
 		}
 	}
 

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -109,8 +109,9 @@ function _pantheon_upstream_update_notice() {
 	// If WP core is a pre-release, alter the message.
 	if ( _pantheon_is_wordpress_core_prerelease() ) {
 		$version = '<span style="font-weight: normal;">(' . $wp_version . ')</span>';
+		$paragraph_style = esc_attr( 'font-size: 14px;' );
 		// Translators: %s is the current WordPress version.
-		$notice_message = sprintf( __( 'You are using a development version of WordPress. %s', 'pantheon-systems' ), $version );
+		$notice_message = sprintf( __( '<strong>You are using a development version of WordPress.</strong> %s', 'pantheon-systems' ), $version );
 		// If we're on the Updates page, add a note about the Beta Tester plugin.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			$notice_message .= '<br /><span style="font-weight: normal;">';

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -104,7 +104,7 @@ function _pantheon_upstream_update_notice() {
 		// If we're on the Updates page, add a note about the Beta Tester plugin.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			$notice_message .= '<br /><span style="font-weight: normal;">';
-			$notice_message .= __( 'You are responsible for keeping WordPress up-to-date. Pantheon updates to WordPress will not appear in the dashboard. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' );
+			$notice_message .= __( 'You are responsible for keeping WordPress up-to-date. Pantheon updates to WordPress will not appear in the dashboard as long as you\'re using a development version. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' );
 		}
 	}
 

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -1,14 +1,14 @@
 <?php
 // If on Pantheon
-if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ){
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	// Disable WordPress auto updates
-	if( ! defined('WP_AUTO_UPDATE_CORE')) {
+	if ( ! defined( 'WP_AUTO_UPDATE_CORE' ) ) {
 		define( 'WP_AUTO_UPDATE_CORE', false );
 	}
 
 	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
 	// Remove the default WordPress core update nag
-    add_action('admin_menu','_pantheon_hide_update_nag');
+	add_action( 'admin_menu', '_pantheon_hide_update_nag' );
 }
 
 function _pantheon_hide_update_nag() {
@@ -20,7 +20,7 @@ function _pantheon_hide_update_nag() {
 function _pantheon_get_latest_wordpress_version() {
 	$core_updates = get_core_updates();
 
-	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+	if ( ! is_array( $core_updates ) || empty( $core_updates ) || ! property_exists( $core_updates[0], 'current' ) ) {
 		return null;
 	}
 
@@ -35,12 +35,12 @@ function _pantheon_get_latest_wordpress_version() {
 function _pantheon_is_wordpress_core_latest() : bool {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
 
-	if( null === $latest_wp_version ){
+	if ( null === $latest_wp_version ) {
 		return true;
 	}
 
 	// include an unmodified $wp_version
-	include( ABSPATH . WPINC . '/version.php' );
+	include ABSPATH . WPINC . '/version.php';
 
 	// Return true if our version is the latest
 	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' );
@@ -77,7 +77,9 @@ function _pantheon_upstream_update_notice() {
 	} else {
 		// If WP core is out of date, alter the message and show the nag everywhere.
 		// Translators: %s is a URL to the user's Pantheon Dashboard.
-		$notice_message = wp_kses_post( sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );; ?>
+		$notice_message = wp_kses_post( sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );
+ 
+		?>
 		<div class="<?php echo $div_class; ?>" style="<?php echo $div_style; ?>">
 			<p style="<?php echo $paragraph_style; ?>">
 				<?php echo $notice_message; ?>
@@ -92,10 +94,10 @@ function _pantheon_upstream_update_notice() {
 
 // Register Pantheon specific WordPress update admin notice
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
-function _pantheon_register_upstream_update_notice(){
+function _pantheon_register_upstream_update_notice() {
 	// but only if we are on Pantheon
 	// and this is not a WordPress Ajax request
-	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && ! wp_doing_ajax() ){
+	if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && ! wp_doing_ajax() ) {
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 		add_action( 'network_admin_notices', '_pantheon_upstream_update_notice' );
 	}
@@ -104,16 +106,16 @@ function _pantheon_register_upstream_update_notice(){
 // Return zero updates and current time as last checked time
 function _pantheon_disable_wp_updates() {
 	include ABSPATH . WPINC . '/version.php';
-	return (object) array(
-		'updates' => array(),
+	return (object) [
+		'updates' => [],
 		'version_checked' => $wp_version,
 		'last_checked' => time(),
-	);
+	];
 }
 
 // In the Test and Live environments, clear plugin/theme update notifications.
 // Users must check a dev or multidev environment for updates.
-if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live') ) && (php_sapi_name() !== 'cli') ) {
+if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ] ) && ( php_sapi_name() !== 'cli' ) ) {
 
 	// Disable Plugin Updates
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -100,7 +100,12 @@ function _pantheon_upstream_update_notice() {
 
 	if ( _pantheon_is_wordpress_core_prerelease() ) {
 		// If WP core is a pre-release, alter the message.
-		$notice_message = sprintf( __( 'You are using a development version of WordPress. <strong>You are responsible for keeping WordPress up-to-date.</strong> Pantheon updates to WordPress will not appear in the dashboard. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' ) );
+		$notice_message = __( 'You are using a development version of WordPress.', 'pantheon-systems' );
+		// If we're on the Updates page, add a note about the Beta Tester plugin.
+		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
+			$notice_message .= '<br /><span style="font-weight: normal;">';
+			$notice_message .= __( 'You are responsible for keeping WordPress up-to-date. Pantheon updates to WordPress will not appear in the dashboard. If you are using the Beta Tester plugin, you must have your site in SFTP mode to get the latest updates to your Pantheon Dev environment.', 'pantheon-systems' );
+		}
 	}
 
 	ob_start();
@@ -117,7 +122,7 @@ function _pantheon_upstream_update_notice() {
 	</div>
 	<?php
 	$notice_html = ob_get_clean();
-	if ( _pantheon_is_wordpress_core_latest() || _pantheon_is_wordpress_core_prerelease() ) {
+	if ( _pantheon_is_wordpress_core_latest() ) {
 		// If a WP core update is not detected, only show the nag on the updates page.
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			// Escaping is handled above when we're buffering the output, so we can ignore it here.

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -82,6 +82,7 @@ function _pantheon_is_wordpress_core_prerelease() : bool {
  * @return void
  */
 function _pantheon_upstream_update_notice() {
+	$screen = get_current_screen();
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
 	$notice_message = sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
 	// Translators: %s is a URL to Pantheon's upstream updates documentation.
@@ -118,7 +119,6 @@ function _pantheon_upstream_update_notice() {
 	$notice_html = ob_get_clean();
 	if ( _pantheon_is_wordpress_core_latest() || _pantheon_is_wordpress_core_prerelease() ) {
 		// If a WP core update is not detected, only show the nag on the updates page.
-		$screen = get_current_screen();
 		if ( 'update-core' === $screen->id || 'update-core-network' === $screen->id ) {
 			// Escaping is handled above when we're buffering the output, so we can ignore it here.
 			echo $notice_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -16,8 +16,12 @@ function _pantheon_hide_update_nag() {
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
 }
 
-// Get the latest WordPress version
-function _pantheon_get_latest_wordpress_version() {
+/**
+ * Get the latest WordPress version
+ *
+ * @return string|null
+ */
+function _pantheon_get_latest_wordpress_version() : ?string {
 	$core_updates = get_core_updates();
 
 	if ( ! is_array( $core_updates ) || empty( $core_updates ) || ! property_exists( $core_updates[0], 'current' ) ) {
@@ -47,9 +51,12 @@ function _pantheon_is_wordpress_core_latest() : bool {
 
 }
 
-
-
-// Replace WordPress core update nag EVERYWHERE with our own notice (use git upstream)
+/**
+ * Replace WordPress core update nag EVERYWHERE with our own notice
+ * (use git upstream)
+ *
+ * @return void
+ */
 function _pantheon_upstream_update_notice() {
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
 	$notice_message = wp_kses_post( sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );
@@ -78,7 +85,7 @@ function _pantheon_upstream_update_notice() {
 		// If WP core is out of date, alter the message and show the nag everywhere.
 		// Translators: %s is a URL to the user's Pantheon Dashboard.
 		$notice_message = wp_kses_post( sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) );
- 
+
 		?>
 		<div class="<?php echo $div_class; ?>" style="<?php echo $div_style; ?>">
 			<p style="<?php echo $paragraph_style; ?>">
@@ -92,8 +99,11 @@ function _pantheon_upstream_update_notice() {
 	}
 }
 
-// Register Pantheon specific WordPress update admin notice
-add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
+/**
+ * Register Pantheon specific WordPress update admin notice
+ *
+ * @return void
+ */
 function _pantheon_register_upstream_update_notice() {
 	// but only if we are on Pantheon
 	// and this is not a WordPress Ajax request
@@ -102,9 +112,14 @@ function _pantheon_register_upstream_update_notice() {
 		add_action( 'network_admin_notices', '_pantheon_upstream_update_notice' );
 	}
 }
+add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
 
-// Return zero updates and current time as last checked time
-function _pantheon_disable_wp_updates() {
+/**
+ * Return zero updates and current time as last checked time
+ *
+ * @return object
+ */
+function _pantheon_disable_wp_updates() : object {
 	include ABSPATH . WPINC . '/version.php';
 	return (object) [
 		'updates' => [],


### PR DESCRIPTION
Fixes #12

When using a development/pre-release version of WordPress, WordPress notifies the user that an update is available. While this might be _technically true_ -- development versions always have a newer version available if you're on the nightly channel -- the message that says to apply those updates in the Pantheon dashboard is not.

In fact, we _don't_ want people to be applying (or attempt to apply) WordPress updates in the Pantheon dashboard if they're using development versions -- if an update ever showed up there, it would overwrite the development version of  WordPress that was installed.

This PR addresses the issue by displaying a unique message if a user is running a development version of WordPress. 

This PR also adds our WP Coding Standards so the refactored `plugin-updates.php` can adhere to our standards, but does not otherwise add a linting workflow to the repository as a whole.

* adds Pantheon WP Coding Standards so linting can be run on affected files
* updates `pantheon-updates.php` to current Pantheon WP standards
* adds a new helper function that returns the current WP version
* adjusts `_pantheon_is_wordpress_core_latest` to not flag on development versions
* adds a new helper function that checks if the current version of WP is a development version
* updates the update notice to make it more DRY
* adds a check and notice message if a development version of WordPress is found