### PR TITLE
Add alert if site has a low cache hit ratio

### DIFF
--- a/inc/pantheon-metrics.php
+++ b/inc/pantheon-metrics.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * If this is a Pantheon site, show a notice about low cache hit ratio
+ *
+ * @package pantheon
+ */
+
+// If on Pantheon...
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+	add_action( 'admin_notices', '_pantheon_metrics_notice' );
+	add_action( 'network_admin_notices', '_pantheon_metrics_notice' );
+}
+
+/**
+ * Fetch traffic metrics from the Pantheon API
+ *
+ * @return array
+ */
+function _pantheon_get_metrics() {
+	$metrics = get_transient( '_pantheon_metrics' );
+	if ( $metrics != false ) {
+		return $metrics;
+	}
+	if ( true == get_transient( '_pantheon_metrics_no_retry' ) ) {
+		return false;
+	}
+	$url = 'https:/api.live.getpantheon.com/sites/self/environments/live/traffic?duration=28d';
+	$req = pantheon_curl( $url, NULL, 8443 );
+	if( 200 != $req['status-code'] || ! $req['body'] ) {
+		// Don't retry for two minutes
+		set_transient( '_pantheon_metrics_no_retry', true, 120 );
+		return false;
+	}
+	$metrics = json_decode( $req['body'], TRUE );
+	set_transient( '_pantheon_metrics', $metrics['timeseries'], 86400);
+	return $metrics['timeseries'];
+}
+
+/**
+ * Get the most recent day's cache hit ratio
+ *
+ * @return int Cache hit ratio, or false on error
+ */
+function _pantheon_get_cache_hit_ratio() {
+	$metrics = _pantheon_get_metrics();
+	if ( ! $metrics ) {
+		return false;
+	}
+	$last_day = array_pop($metrics);
+	if ( ! $last_day['pages_served'] ) {
+		return false;
+	}
+	return number_format( $last_day['cache_hits'] / $last_day['pages_served'] * 100, 0);
+}
+
+/**
+ * Add a notice of low cache hit ratio on the dashboard and site health pages
+ *
+ * @return void
+ */
+function _pantheon_metrics_notice() {
+	$cache_hit_ratio = _pantheon_get_cache_hit_ratio();
+	if($cache_hit_ratio > 50 || $cache_hit_ratio === false) {
+		return false;
+	}
+	$screen = get_current_screen();
+	if ( 'dashboard' === $screen->id || 'site-health' === $screen->id ) {
+	?>
+		<div class="update-nag notice notice-warning is-dismissible" style="display: table;">
+			<p style="font-size: 14px; margin: 0;">
+				<?php
+				// Translators: %s is a URL to the user's Pantheon Dashboard.
+				echo wp_kses_post( sprintf( __( 'The live site is currently only serving %d%% of traffic from the GCDN cache. See more details in the <a href="%s">Metrics tab</a> in your Pantheon dashboard.', 'pantheon-systems' ), $cache_hit_ratio, 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#live/metrics' ) );
+				?>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/pantheon.php
+++ b/pantheon.php
@@ -22,9 +22,12 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( 'dev' === $_ENV['PANTHEON_ENVIRONMENT'] && function_exists( 'wp_is_writable' ) ) {
 		require_once 'inc/pantheon-plugin-install-notice.php';
 	}
-    if ( defined( 'WP_CLI' ) && WP_CLI ) {
-        require_once 'inc/cli.php';
-    }
+	if ( ! defined('SHOW_PANTHEON_METRICS_NOTICE') || SHOW_PANTHEON_METRICS_NOTICE ) {
+		require_once 'inc/pantheon-metrics.php';
+	}
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		require_once 'inc/cli.php';
+	}
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
 		 * When this constant is not set, WordPress writes and then deletes a
@@ -37,15 +40,15 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		 */
 		define( 'FS_METHOD', 'direct' );
 	}
-    // When developing a WordPress Multisite locally, ensure that this constant is set.
-    // This will set the Multisite variable in all Pantheon environments.
-    if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
-        define( 'WP_ALLOW_MULTISITE', true );
-    }
-    if ( defined( 'MULTISITE' ) && defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
-	require_once 'inc/pantheon-network-setup.php';
-    }
-    if ( defined( 'WP_ALLOW_MULTISITE' ) && ( ! defined( 'MULTISITE' ) || empty( MULTISITE ) ) ) {
-        require_once 'inc/pantheon-multisite-finalize.php';
-    }
+	// When developing a WordPress Multisite locally, ensure that this constant is set.
+	// This will set the Multisite variable in all Pantheon environments.
+	if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
+		define( 'WP_ALLOW_MULTISITE', true );
+	}
+	if ( defined( 'MULTISITE' ) && defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
+		require_once 'inc/pantheon-network-setup.php';
+	}
+	if ( defined( 'WP_ALLOW_MULTISITE' ) && ( ! defined( 'MULTISITE' ) || empty( MULTISITE ) ) ) {
+		require_once 'inc/pantheon-multisite-finalize.php';
+	}
 } // Ensuring that this is on Pantheon.


### PR DESCRIPTION
Checks the Pantheon API for the last day's traffic on the Live environment.

If the Cache Hit Ratio is below 50% an alert will be shown on the WordPress dashboard and site health screens.

Results are cached for one day. If there is a curl failure it will be retried after two minutes.

<img width="1149" alt="image" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/91161717/e008ac46-6492-4cf1-8569-8836077c0619">