### PR TITLE
[BUGS-6657] Handle explicit WP_ALLOW_MULTISITE false correctly

### DIFF
--- a/inc/pantheon-multisite-finalize.php
+++ b/inc/pantheon-multisite-finalize.php
@@ -23,7 +23,7 @@ function pantheon_multisite_install_finalize_message() { ?>
 			} else {
 				?>
 					<p><?php esc_html_e( 'You are trying to configure a WordPress Multisite with a wrong upstream!', 'pantheon' ); ?></p>
-					<p><?php echo sprintf( __( 'Make sure that you have the correct upstream configuration for WPMS. If you do not have that capability or check if you are eligible, please <a href="%s">Contact Support</a>.', 'pantheon' ), 'https://pantheon.io/support' ); ?></p>
+					<p><?php echo sprintf( __( 'Make sure that you have the correct upstream configuration for WPMS. If you do not have that capability or to check if you are eligible, please <a href="%s">Contact Support</a>.', 'pantheon' ), 'https://pantheon.io/support' ); ?></p>
 				<?php
 			}
 		}

--- a/pantheon.php
+++ b/pantheon.php
@@ -42,11 +42,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
     if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
         define( 'WP_ALLOW_MULTISITE', true );
     }
-    if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
-	    if ( defined( 'MULTISITE' ) && MULTISITE ) {
+	if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
+		if ( defined( 'MULTISITE' ) && MULTISITE ) {
 			require_once 'inc/pantheon-network-setup.php';
-	    } else {
+		} else {
 			require_once 'inc/pantheon-multisite-finalize.php';
-	    }
-    }
+		}
+	}
 } // Ensuring that this is on Pantheon.

--- a/pantheon.php
+++ b/pantheon.php
@@ -16,15 +16,15 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( ! defined( 'DISABLE_PANTHEON_UPDATE_NOTICES' ) || ! DISABLE_PANTHEON_UPDATE_NOTICES ) {
 		require_once 'inc/pantheon-updates.php';
 	}
-	if ( ! defined('RETURN_TO_PANTHEON_BUTTON') || RETURN_TO_PANTHEON_BUTTON ) {
+	if ( ! defined( 'RETURN_TO_PANTHEON_BUTTON' ) || RETURN_TO_PANTHEON_BUTTON ) {
 		require_once 'inc/pantheon-login-form-mods.php';
 	}
 	if ( 'dev' === $_ENV['PANTHEON_ENVIRONMENT'] && function_exists( 'wp_is_writable' ) ) {
 		require_once 'inc/pantheon-plugin-install-notice.php';
 	}
-    if ( defined( 'WP_CLI' ) && WP_CLI ) {
-        require_once 'inc/cli.php';
-    }
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		require_once 'inc/cli.php';
+	}
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
 		 * When this constant is not set, WordPress writes and then deletes a
@@ -37,11 +37,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		 */
 		define( 'FS_METHOD', 'direct' );
 	}
-    // When developing a WordPress Multisite locally, ensure that this constant is set.
-    // This will set the Multisite variable in all Pantheon environments.
-    if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
-        define( 'WP_ALLOW_MULTISITE', true );
-    }
+	// When developing a WordPress Multisite locally, ensure that this constant is set.
+	// This will set the Multisite variable in all Pantheon environments.
+	if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
+		define( 'WP_ALLOW_MULTISITE', true );
+	}
 	if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
 		if ( defined( 'MULTISITE' ) && MULTISITE ) {
 			require_once 'inc/pantheon-network-setup.php';

--- a/pantheon.php
+++ b/pantheon.php
@@ -42,10 +42,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
     if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
         define( 'WP_ALLOW_MULTISITE', true );
     }
-    if ( defined( 'MULTISITE' ) && defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
-	require_once 'inc/pantheon-network-setup.php';
-    }
-    if ( defined( 'WP_ALLOW_MULTISITE' ) && ( ! defined( 'MULTISITE' ) || empty( MULTISITE ) ) ) {
-        require_once 'inc/pantheon-multisite-finalize.php';
+    if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
+	    if ( defined( 'MULTISITE' ) && MULTISITE ) {
+			require_once 'inc/pantheon-network-setup.php';
+	    } else {
+			require_once 'inc/pantheon-multisite-finalize.php';
+	    }
     }
 } // Ensuring that this is on Pantheon.


### PR DESCRIPTION
Sites with `define('WP_ALLOW_MULTISITE', false);` are erroneously getting prompted to fix their upstream, as we we only check `WP_ALLOW_MULTISITE` was set, not its value.

Further consolidated the logic given we were checking both WP_ALLOW_MULTISITE and MULTISITE back-to-back