### PR TITLE
[CMSP-669] Update pantheon wp coding standards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,5 @@
 /.phpcs.xml export-ignore
 /CODEOWNERS export-ignore
 /composer.lock export-ignore
+/CONTRIBUTING.md export-ignore
 /phpunit.xml.dist export-ignore # This also doesn't exist, but hopefully one day...

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Directories
+/.github export-ignore
+/tests export-ignore # This doesn't exist yet, but hopefully it will in the future.
+/vendor export-ignore
+
+# Files
+/.DS_Store export-ignore
+/Thumb.db export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.phpcs.xml export-ignore
+/CODEOWNERS export-ignore
+/composer.lock export-ignore
+/phpunit.xml.dist export-ignore # This also doesn't exist, but hopefully one day...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+on: push
+jobs:
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Lint
+              run: |
+                composer install
+                composer lint

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<ruleset name="Pantheon WP Coding Standards">
+	<description>Pantheon WordPress Coding Standards.</description>
+
+	<!-- What to scan -->
+	<file>.</file>
+	<exclude-pattern>/vendor/</exclude-pattern>
+	<exclude-pattern>/assets/</exclude-pattern>
+
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
+	<arg name="colors"/>
+	<arg name="extensions" value="php"/>
+	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
+
+	<!-- Rules: Check PHP version compatibility -->
+	<config name="testVersion" value="7.4-"/>
+	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- Rules: Pantheon WP WordPress Coding Standards -->
+	<config name="minimum_supported_wp_version" value="4.6"/>
+	<rule ref="Pantheon-WP">
+		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery">
+			<exclude-pattern>*/*</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching">
+			<exclude-pattern>inc/network/includes-network.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.Security.NonceVerification.Missing">
+			<exclude-pattern>inc/network/includes-network.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.Security.NonceVerification.Recommended">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated">
+			<exclude-pattern>inc/network/includes-network.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
+			<exclude-pattern>inc/network/includes-network.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath">
+			<exclude-pattern>pantheon.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName">
+			<exclude-pattern>*/*</exclude-pattern>
+		</exclude>
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+		<exclude name="Universal.Files.SeparateFunctionsFromOO.Mixed">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+
+		<!-- Ignore missing doc comments in pantheon-page-cache.php for now. -->
+		<exclude name="Squiz.Commenting.FunctionComment.Missing">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+		<exclude name="Generic.Commenting.DocComment.MissingShort">
+			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
+		</exclude>
+	</rule>
+</ruleset>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Workflow
+Development is based off of the `main` branch. There is no `release` branch. Releases are cut from `main` as and when ready. Composer-based sites can pull the latest release as normal, whereas [pantheon-systems/WordPress](https://github.com/pantheon-systems/WordPress) -- which is used for the [WordPress Upstream](https://docs.pantheon.io/wordpress/) -- is updated through automation powered by [Update Tool](https://github.com/pantheon-systems/update-tool/).
+
+Update Tool clones whatever the latest code on `main` is, and manually removes files that are not required for WordPress sites (e.g. `composer.json`, `composer.lock`, `README.md`, etc.). This is then bundled as part of WordPress releases and upstream updates.
+
+Because the WordPress upstream is only updated when a new WordPress release is cut, it's less risky that we don't have an explicit `develop` branch, but `main` should still always be in a stable state in the chance that a WordPress bugfix or security release is pushed unexpectedly.
+
+## Release Process
+
+When you are ready for a new `pantheon-mu-plugin` release, before cutting a new release, there are a few steps that need to be taken before you do so.
+
+1. Update the version number in `pantheon.php` in the plugin header and the `PANTHEON_MU_PLUGIN_VERSION` constant.
+1. If there were any new files that were added to the plugin that should be excluded from the WordPress upstream, add them to the `.gitattributes` file with `export-ignore` and be sure to add them to the `$files_to_delete` array in [`update-tool/src/Update/Filters/CopyMuPlugin.php`](https://github.com/pantheon-systems/update-tool/blob/master/src/Update/Filters/CopyMuPlugin.php).
+1. Use the GitHub UI to create a new release. The tag should be the version number only (not prefixed with `v`, e.g. `1.2.1`). Use the GitHub tools to autocomplete the title and body of the release with the changelog. The release should be created from the `main` branch.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "vlucas/phpdotenv": "*"
   },
   "require-dev": {
-    "pantheon-systems/pantheon-wp-coding-standards": "^1.0"
+    "pantheon-systems/pantheon-wp-coding-standards": "^2.0"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "lint": "vendor/bin/phpcs -s --standard=Pantheon-WP .",
-    "lint:cbf": "vendor/bin/phpcbf -s --standard=Pantheon-WP ."
+    "lint": "vendor/bin/phpcs -s .",
+    "lint:cbf": "vendor/bin/phpcbf -s ."
   }
 }

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -48,8 +48,9 @@ WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_main
  */
 function __deprecated_maintenance_mode_output( $args ) {
 	$allowed_args = [ 'disabled', 'anonymous', 'everyone' ];
-	$replacement_command = ( ! empty( $args  && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
+	$replacement_command = ( ! empty( $args && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
 
+	// translators: %s is the replacement command.
 	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated and will be removed in a future release. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
 	WP_CLI::line( __( 'Run `wp pantheon set-maintenance-mode --help` for more information.', 'pantheon-systems' ) );
 

--- a/inc/network/network.php
+++ b/inc/network/network.php
@@ -13,17 +13,17 @@ define( 'WP_INSTALLING_NETWORK', true );
 require_once ABSPATH . 'wp-admin/admin.php';
 
 if ( ! current_user_can( 'setup_network' ) ) {
-	wp_die( __( 'Sorry, you are not allowed to manage options for this site.' ) );
+	wp_die( esc_html__( 'Sorry, you are not allowed to manage options for this site.' ) );
 }
 
 if ( is_multisite() ) {
 	if ( ! is_network_admin() ) {
-		wp_redirect( network_admin_url( 'setup.php' ) );
+		wp_safe_redirect( network_admin_url( 'setup.php' ) );
 		exit;
 	}
 
 	if ( ! defined( 'MULTISITE' ) ) {
-		wp_die( __( 'The Network creation panel is not for WordPress MU networks.' ) );
+		wp_die( esc_html__( 'The Network creation panel is not for WordPress MU networks.' ) );
 	}
 }
 
@@ -36,9 +36,9 @@ foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table ) {
 
 if ( ! network_domain_check() && ( ! defined( 'WP_ALLOW_MULTISITE' ) || ! WP_ALLOW_MULTISITE ) ) {
 	wp_die(
-		printf(
+		printf( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			/* translators: 1: WP_ALLOW_MULTISITE, 2: wp-config.php */
-			__( 'You must define the %1$s constant as true in your %2$s file to allow creation of a Network.' ),
+			esc_html__( 'You must define the %1$s constant as true in your %2$s file to allow creation of a Network.' ),
 			'<code>WP_ALLOW_MULTISITE</code>',
 			'<code>wp-config.php</code>'
 		)
@@ -47,15 +47,13 @@ if ( ! network_domain_check() && ( ! defined( 'WP_ALLOW_MULTISITE' ) || ! WP_ALL
 
 if ( is_network_admin() ) {
 	// Used in the HTML title tag.
-	$title       = __( 'Network Setup' );
-	$parent_file = 'settings.php';
+	$page_title = esc_html__( 'Network Setup' );
 } else {
 	// Used in the HTML title tag.
-	$title       = __( 'Create a Network of WordPress Sites' );
-	$parent_file = 'tools.php';
+	$page_title = __( 'Create a Network of WordPress Sites' );
 }
 
-$network_help = '<p>' . __( 'This screen allows you to configure a network as having subdomains (<code>site1.example.com</code>) or subdirectories (<code>example.com/site1</code>). Subdomains require wildcard subdomains to be enabled in Apache and DNS records, if your host allows it.' ) . '</p>' .
+$network_help = wp_kses_post( '<p>' . __( 'This screen allows you to configure a network as having subdomains (<code>site1.example.com</code>) or subdirectories (<code>example.com/site1</code>). Subdomains require wildcard subdomains to be enabled in Apache and DNS records, if your host allows it.' ) . '</p>' .
 	'<p>' . __( 'Choose subdomains or subdirectories; this can only be switched afterwards by reconfiguring your installation. Fill out the network details, and click Install. If this does not work, you may have to add a wildcard DNS record (for subdomains) or change to another setting in Permalinks (for subdirectories).' ) . '</p>' .
 	'<p>' . __( 'The next screen for Network Setup will give you individually-generated lines of code to add to your wp-config.php and .htaccess files. Make sure the settings of your FTP client make files starting with a dot visible, so that you can find .htaccess; you may have to create this file if it really is not there. Make backup copies of those two files.' ) . '</p>' .
 	'<p>' . __( 'Add the designated lines of code to wp-config.php (just before <code>/*...stop editing...*/</code>) and <code>.htaccess</code> (replacing the existing WordPress rules).' ) . '</p>' .
@@ -63,14 +61,14 @@ $network_help = '<p>' . __( 'This screen allows you to configure a network as ha
 	'<p>' . __( 'The choice of subdirectory sites is disabled if this setup is more than a month old because of permalink problems with &#8220;/blog/&#8221; from the main site. This disabling will be addressed in a future version.' ) . '</p>' .
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/article/create-a-network/">Documentation on Creating a Network</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/support/article/tools-network-screen/">Documentation on the Network Screen</a>' ) . '</p>';
+	'<p>' . __( '<a href="https://wordpress.org/support/article/tools-network-screen/">Documentation on the Network Screen</a>' ) . '</p>' ); // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 
 get_current_screen()->add_help_tab(
-	array(
+	[
 		'id'      => 'network',
 		'title'   => __( 'Network' ),
 		'content' => $network_help,
-	)
+	]
 );
 
 get_current_screen()->set_help_sidebar(
@@ -83,7 +81,7 @@ get_current_screen()->set_help_sidebar(
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 <div class="wrap">
-<h1><?php echo esc_html( $title ); ?></h1>
+<h1><?php echo esc_html( $page_title ); ?></h1>
 
 <?php
 if ( $_POST ) {

--- a/inc/pantheon-login-form-mods.php
+++ b/inc/pantheon-login-form-mods.php
@@ -9,64 +9,61 @@
  * Only if we are on a Pantheon subdomain
  */
 $show_return_to_pantheon_button = apply_filters( 'show_return_to_pantheon_button', (
-    (
-        false !== stripos( get_site_url(), 'pantheonsite.io') ||
-        ( isset( $_SERVER['HTTP_HOST'] ) && false !== stripos( $_SERVER['HTTP_HOST'], 'pantheonsite.io') )
-    )
+	(
+		false !== stripos( get_site_url(), 'pantheonsite.io' ) ||
+		( isset( $_SERVER['HTTP_HOST'] ) && false !== stripos( $_SERVER['HTTP_HOST'], 'pantheonsite.io' ) )
+	)
 ) );
 
-if( $show_return_to_pantheon_button ){
+if ( $show_return_to_pantheon_button ) {
 
-    /**
-     * Enqueue Pantheon login styles
-     *
-     * @return void
-     */
-    function Pantheon_Enqueue_Login_style()
-    {
-        wp_enqueue_style('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/css/return-to-pantheon-button.css', false); 
-    }
+	/**
+	 * Enqueue Pantheon login styles
+	 *
+	 * @return void
+	 */
+	function Pantheon_Enqueue_Login_style() {
+		wp_enqueue_style( 'pantheon-login-mods', plugin_dir_url( __FILE__ ) . 'assets/css/return-to-pantheon-button.css', false, PANTHEON_MU_PLUGIN_VERSION );
+	}
 
-    add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_style', 10);
+	add_action( 'login_enqueue_scripts', 'Pantheon_Enqueue_Login_style', 10 );
 
-    /**
-     * Enqueue Pantheon login scripts
-     *
-     * @return void
-     */
-    function Pantheon_Enqueue_Login_script()
-    {
-        wp_enqueue_script('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/js/return-to-pantheon-button.js', array('jquery'), false, true);
-    }
+	/**
+	 * Enqueue Pantheon login scripts
+	 *
+	 * @return void
+	 */
+	function Pantheon_Enqueue_Login_script() {
+		wp_enqueue_script( 'pantheon-login-mods', plugin_dir_url( __FILE__ ) . 'assets/js/return-to-pantheon-button.js', [ 'jquery' ], PANTHEON_MU_PLUGIN_VERSION, true );
+	}
 
-    add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_script', 1);
+	add_action( 'login_enqueue_scripts', 'Pantheon_Enqueue_Login_script', 1 );
 
-    /**
-     * Print return to Pantheon link HTML
-     *
-     * @return void
-     */
-    function Return_To_Pantheon_Button_HTML()
-    {
-        $pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
+	/**
+	 * Print return to Pantheon link HTML
+	 *
+	 * @return void
+	 */
+	function Return_To_Pantheon_Button_HTML() {
+		$pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
 
-        $pantheon_fist_icon_url = plugin_dir_url(__FILE__) . 'assets/images/pantheon-fist-icon-black.svg';
-        $login_message = apply_filters( 'pantheon_wp_login_text', __('Login to your WordPress Site', 'pantheon') );
-        ?>
-        <div id="return-to-pantheon" style="display: none;">
-            <div class="left">
-                    <?php echo $login_message; ?>
-            </div>
-            <div class="right">
-                <a href="<?php echo esc_url( $pantheon_dashboard_url ); ?>">
-                    <img class="fist-icon"  src="<?php echo esc_url( $pantheon_fist_icon_url ); ?>">
-                    <?php _e('Return to Pantheon', 'pantheon'); ?>
-                </a>
-            </div>
-        </div>
-        <?php
-    }
+		$pantheon_fist_icon_url = plugin_dir_url( __FILE__ ) . 'assets/images/pantheon-fist-icon-black.svg';
+		$login_message = apply_filters( 'pantheon_wp_login_text', esc_html__( 'Login to your WordPress Site', 'pantheon' ) );
+		?>
+		<div id="return-to-pantheon" style="display: none;">
+			<div class="left">
+					<?php echo $login_message; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</div>
+			<div class="right">
+				<a href="<?php echo esc_url( $pantheon_dashboard_url ); ?>">
+					<img class="fist-icon"  src="<?php echo esc_url( $pantheon_fist_icon_url ); ?>">
+					<?php esc_html_e( 'Return to Pantheon', 'pantheon' ); ?>
+				</a>
+			</div>
+		</div>
+		<?php
+	}
 
-    add_action('login_header', 'Return_To_Pantheon_Button_HTML', 10);
+	add_action( 'login_header', 'Return_To_Pantheon_Button_HTML', 10 );
 
 }

--- a/inc/pantheon-multisite-finalize.php
+++ b/inc/pantheon-multisite-finalize.php
@@ -11,19 +11,39 @@
  *
  * @return void
  */
-function pantheon_multisite_install_finalize_message() { ?>
+function pantheon_multisite_install_finalize_message() {
+	?>
 	<div class="notice notice-info is-dismissible">
 		<?php
 		if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 			if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' ) {
 				?>
 					<p><?php esc_html_e( 'Your WordPress Multisite is almost ready!', 'pantheon' ); ?></p>
-					<p><?php echo sprintf( __( 'Visit <a href="%s">Pantheon Multisite Configuration</a> for documentation on how to finalize configuration of your site network.', 'pantheon' ), 'https://pantheon.io/docs/guides/multisite/config/#install-the-wordpress-site-network' ); ?></p>
+					<p>
+						<?php
+						printf(
+							wp_kses_post(
+								// translators: %s is the link to the Pantheon Multisite Configuration documentation.
+								__( 'Visit <a href="%s">Pantheon Multisite Configuration</a> for documentation on how to finalize configuration of your site network.', 'pantheon' )
+							),
+							'https://pantheon.io/docs/guides/multisite/config/#install-the-wordpress-site-network'
+						);
+						?>
+					</p>
 				<?php
 			} else {
 				?>
 					<p><?php esc_html_e( 'You are trying to configure a WordPress Multisite with a wrong upstream!', 'pantheon' ); ?></p>
-					<p><?php echo sprintf( __( 'Make sure that you have the correct upstream configuration for WPMS. If you do not have that capability or to check if you are eligible, please <a href="%s">Contact Support</a>.', 'pantheon' ), 'https://pantheon.io/support' ); ?></p>
+					<p>
+						<?php
+						printf(
+							wp_kses_post(
+								// translators: %s is the link to the Pantheon Support page.
+								__( 'Make sure that you have the correct upstream configuration for WPMS. If you do not have that capability or to check if you are eligible, please <a href="%s">Contact Support</a>.', 'pantheon' )
+							), 'https://pantheon.io/support'
+						);
+						?>
+					</p>
 				<?php
 			}
 		}

--- a/inc/pantheon-network-setup.php
+++ b/inc/pantheon-network-setup.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Network Setup
+ *
+ * @package pantheon-mu-plugin
+ */
 
 namespace Pantheon\NetworkSetup;
 
@@ -11,9 +16,9 @@ namespace Pantheon\NetworkSetup;
  */
 function pantheon_remove_network_setup() {
 	global $submenu;
-    if ( isset( $submenu['tools.php'][50] ) ) {
-	    unset( $submenu['tools.php'][50] );
-    }
+	if ( isset( $submenu['tools.php'][50] ) ) {
+		unset( $submenu['tools.php'][50] );
+	}
 }
 
 /**
@@ -25,7 +30,7 @@ function pantheon_add_network_setup() {
 		__( 'Network Setup', 'network-setup' ),
 		'setup_network',
 		'setup_network',
-		 __NAMESPACE__ . '\\pantheon_render_network_setup_page'
+		__NAMESPACE__ . '\\pantheon_render_network_setup_page'
 	);
 }
 
@@ -33,8 +38,8 @@ function pantheon_add_network_setup() {
  * Render the Pantheon network setup page.
  */
 function pantheon_render_network_setup_page() {
-    global $wpdb;
-    require_once __DIR__ . '/network/network.php';
+	global $wpdb;
+	require_once __DIR__ . '/network/network.php';
 }
 
 add_action( 'admin_menu', __NAMESPACE__ . '\\pantheon_remove_network_setup' );

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -1,18 +1,25 @@
 <?php
-/*	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
+/**
+ * Pantheon Page Cache
+ *
+ * @package pantheon-mu-plugin
+ */
 
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*/
+/**
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
 class Pantheon_Cache {
 
 	/**
@@ -27,21 +34,21 @@ class Pantheon_Cache {
 	 *
 	 * @var array
 	 */
-	public $default_options = array();
+	public $default_options = [];
 
 	/**
 	 * Stores the options for this plugin (from wp_options).
 	 *
 	 * @var array
 	 */
-	public $options = array();
+	public $options = [];
 
 	/**
 	 * Store the Paths to be flushed at shutdown.
 	 *
 	 * @var array
 	 */
-	public $paths = array();
+	public $paths = [];
 
 	/**
 	 * The slug for the plugin, used in various places like the options page.
@@ -63,14 +70,14 @@ class Pantheon_Cache {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new Pantheon_Cache;
+			self::$instance = new Pantheon_Cache();
 			self::$instance->setup();
 		}
 		return self::$instance;
 	}
 
 	protected function __construct() {
-		/** Don't do anything **/
+		/** Don't do anything */
 	}
 
 
@@ -80,25 +87,25 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	protected function setup() {
-		$this->options = get_option( self::SLUG, array() );
-		$this->default_options = array(
+		$this->options = get_option( self::SLUG, [] );
+		$this->default_options = [
 			'default_ttl' => 600,
 			'maintenance_mode' => 'disabled',
-		);
+		];
 		$this->options = wp_parse_args( $this->options, $this->default_options );
 
-		add_action( 'init', array( $this, 'action_init_do_maintenance_mode' ) );
+		add_action( 'init', [ $this, 'action_init_do_maintenance_mode' ] );
 
-		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
-		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
-		add_action( 'load-plugin-install.php', array( $this, 'action_load_plugin_install' ) );
+		add_action( 'admin_init', [ $this, 'action_admin_init' ] );
+		add_action( 'admin_menu', [ $this, 'action_admin_menu' ] );
+		add_action( 'load-plugin-install.php', [ $this, 'action_load_plugin_install' ] );
 
-		add_action( 'admin_post_pantheon_cache_flush_site',  array( $this, 'flush_site' ) );
+		add_action( 'admin_post_pantheon_cache_flush_site', [ $this, 'flush_site' ] );
 
-		add_action( 'send_headers',       array( $this, 'cache_add_headers' ) );
-		add_filter( 'rest_post_dispatch', array( $this, 'filter_rest_post_dispatch_send_cache_control' ), 10, 2 );
+		add_action( 'send_headers', [ $this, 'cache_add_headers' ] );
+		add_filter( 'rest_post_dispatch', [ $this, 'filter_rest_post_dispatch_send_cache_control' ], 10, 2 );
 
-		add_action( 'admin_notices', function(){
+		add_action( 'admin_notices', function () {
 			global $wp_object_cache;
 			if ( empty( $wp_object_cache->missing_redis_message ) ) {
 				return;
@@ -106,7 +113,7 @@ class Pantheon_Cache {
 			$wp_object_cache->missing_redis_message = 'Alert! The Pantheon Redis service needs to be enabled before the WP Redis object cache will function properly.';
 		}, 9 ); // Before the message is displayed in the plugin notice.
 
-		add_action( 'shutdown', array( $this, 'cache_clean_urls' ), 999 );
+		add_action( 'shutdown', [ $this, 'cache_clean_urls' ], 999 );
 	}
 
 	/**
@@ -147,8 +154,8 @@ class Pantheon_Cache {
 		}
 
 		wp_die(
-			__( 'Briefly unavailable for scheduled maintenance. Check back in a minute.' ),
-			__( 'Maintenance' ),
+			esc_html__( 'Briefly unavailable for scheduled maintenance. Check back in a minute.' ),
+			esc_html__( 'Maintenance' ),
 			503
 		);
 	}
@@ -159,10 +166,10 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function action_admin_init() {
-		register_setting( self::SLUG, self::SLUG, array( self::$instance, 'sanitize_options' ) );
+		register_setting( self::SLUG, self::SLUG, [ self::$instance, 'sanitize_options' ] );
 		add_settings_section( 'general', false, '__return_false', self::SLUG );
-		add_settings_field( 'default_ttl', null, array( self::$instance, 'default_ttl_field' ), self::SLUG, 'general' );
-		add_settings_field( 'maintenance_mode', null, array( self::$instance, 'maintenance_mode_field' ), self::SLUG, 'general' );
+		add_settings_field( 'default_ttl', null, [ self::$instance, 'default_ttl_field' ], self::SLUG, 'general' );
+		add_settings_field( 'maintenance_mode', null, [ self::$instance, 'maintenance_mode_field' ], self::SLUG, 'general' );
 	}
 
 
@@ -172,7 +179,7 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function action_admin_menu() {
-		add_options_page( __( 'Pantheon Page Cache', 'pantheon-cache' ), __( 'Pantheon Page Cache', 'pantheon-cache' ), $this->options_capability, self::SLUG, array( self::$instance, 'view_settings_page' ) );
+		add_options_page( __( 'Pantheon Page Cache', 'pantheon-cache' ), __( 'Pantheon Page Cache', 'pantheon-cache' ), $this->options_capability, self::SLUG, [ self::$instance, 'view_settings_page' ] );
 	}
 
 	/**
@@ -182,7 +189,7 @@ class Pantheon_Cache {
 		if ( empty( $_GET['action'] ) || 'pantheon-load-infobox' !== $_GET['action'] ) {
 			return;
 		}
-		add_action( 'admin_footer', array( $this, 'action_admin_footer_trigger_plugin_open' ) );
+		add_action( 'admin_footer', [ $this, 'action_admin_footer_trigger_plugin_open' ] );
 	}
 
 	/**
@@ -207,9 +214,9 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function default_ttl_field() {
-		echo '<h3>' . __( 'Default Time to Live (TTL)', 'pantheon-cache' ) . '</h3>';
-		echo '<p>' . __( 'Maximum time a cached page will be served. A higher TTL typically improves site performance.', 'pantheon-cache' ) . '</p>';
-		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" /> ' . __( 'seconds', 'pantheon-cache' );
+		echo '<h3>' . esc_html__( 'Default Time to Live (TTL)', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher TTL typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -218,11 +225,11 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function maintenance_mode_field() {
-		echo '<h3>' . __( 'Maintenance Mode', 'pantheon-cache' ) . '</h3>';
-		echo '<p>' . __( 'Enable maintenance mode to work on your site while serving cached pages to:', 'pantheon-cache' ) . '</p>';
-		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="" ' . checked( 'disabled', $this->options['maintenance_mode'], false ) . ' /> ' . __( 'Disabled', 'pantheon-cache' ) . '</label>';
-		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="anonymous" ' . checked( 'anonymous', $this->options['maintenance_mode'], false ) . ' /> ' . __( 'Logged-Out Visitors', 'pantheon-cache' ) . '</label>';
-		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="everyone" ' . checked( 'everyone', $this->options['maintenance_mode'], false ) . ' /> ' . __( 'Everyone except Administrators', 'pantheon-cache' ) . '</label>';
+		echo '<h3>' . esc_html__( 'Maintenance Mode', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<p>' . esc_html__( 'Enable maintenance mode to work on your site while serving cached pages to:', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="" ' . checked( 'disabled', $this->options['maintenance_mode'], false ) . ' /> ' . esc_html__( 'Disabled', 'pantheon-cache' ) . '</label>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="anonymous" ' . checked( 'anonymous', $this->options['maintenance_mode'], false ) . ' /> ' . esc_html__( 'Logged-Out Visitors', 'pantheon-cache' ) . '</label>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<label style="display: block; margin-bottom: 5px;"><input type="radio" name="' . self::SLUG . '[maintenance_mode]" value="everyone" ' . checked( 'everyone', $this->options['maintenance_mode'], false ) . ' /> ' . esc_html__( 'Everyone except Administrators', 'pantheon-cache' ) . '</label>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 
@@ -235,7 +242,7 @@ class Pantheon_Cache {
 	public function sanitize_options( $in ) {
 		$out = $this->default_options;
 
-		// Validate default_ttl
+		// Validate default_ttl.
 		$out['default_ttl'] = absint( $in['default_ttl'] );
 		if ( $out['default_ttl'] < 60 && isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'live' === $_ENV['PANTHEON_ENVIRONMENT'] ) {
 			$out['default_ttl'] = 60;
@@ -261,7 +268,7 @@ class Pantheon_Cache {
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Pantheon Page Cache', 'pantheon-cache' ); ?></h2>
 
-			<?php if ( ! empty( $_GET['cache-cleared'] ) && 'true' == $_GET['cache-cleared'] ) : ?>
+			<?php if ( ! empty( $_GET['cache-cleared'] ) && 'true' === $_GET['cache-cleared'] ) : ?>
 				<div class="updated below-h2">
 					<p><?php esc_html_e( 'Site cache flushed.', 'pantheon-cache' ); ?></p>
 				</div>
@@ -286,8 +293,8 @@ class Pantheon_Cache {
 				<form action="admin-post.php" method="POST">
 					<input type="hidden" name="action" value="pantheon_cache_flush_site" />
 					<?php wp_nonce_field( 'pantheon-cache-clear-all', 'pantheon-cache-nonce' ); ?>
-					<h3><?php _e( 'Clear Site Cache', 'pantheon-cache' ); ?></h3>
-					<p><?php _e( 'Use with care. Clearing the entire site cache will negatively impact performance for a short period of time.', 'pantheon-cache' ); ?></p>
+					<h3><?php esc_html_e( 'Clear Site Cache', 'pantheon-cache' ); ?></h3>
+					<p><?php esc_html_e( 'Use with care. Clearing the entire site cache will negatively impact performance for a short period of time.', 'pantheon-cache' ); ?></p>
 					<?php submit_button( __( 'Clear Cache', 'pantheon-cache' ), 'secondary' ); ?>
 				</form>
 
@@ -321,7 +328,8 @@ class Pantheon_Cache {
 			 * Permits the Pantheon Advanced Page Cache plugin to add
 			 * supplemental text.
 			 */
-			do_action( 'pantheon_cache_settings_page_bottom' ); ?>
+			do_action( 'pantheon_cache_settings_page_bottom' );
+			?>
 
 		</div>
 		<?php
@@ -333,7 +341,7 @@ class Pantheon_Cache {
 	 * This removes "max-age=0" which could hypothetically be used by
 	 * Varnish on an immediate subsequent request.
 	 *
-	 * @return void
+	 * @return string
 	 */
 	private function get_cache_control_header_value() {
 		if ( ! is_admin() && ! is_user_logged_in() ) {
@@ -359,7 +367,7 @@ class Pantheon_Cache {
 
 	/**
 	 * Send the cache control header for REST API requests
-	 * 
+	 *
 	 * @param WP_REST_Response $response Response.
 	 * @return WP_REST_Response Response.
 	 */
@@ -371,18 +379,19 @@ class Pantheon_Cache {
 	/**
 	 * Clear the cache for the entire site.
 	 *
-	 * @return void
+	 * @return void|false
 	 */
 	public function flush_site() {
-		if ( ! function_exists( 'current_user_can' ) || false == current_user_can( 'manage_options' ) )
+		if ( ! function_exists( 'current_user_can' ) || false === current_user_can( 'manage_options' ) ) {
 			return false;
+		}
 
 		if ( ! empty( $_POST['pantheon-cache-nonce'] ) && wp_verify_nonce( $_POST['pantheon-cache-nonce'], 'pantheon-cache-clear-all' ) ) {
 			if ( function_exists( 'pantheon_clear_edge_all' ) ) {
 				pantheon_clear_edge_all();
 			}
 			wp_cache_flush();
-			wp_redirect( admin_url( 'options-general.php?page=pantheon-cache&cache-cleared=true' ) );
+			wp_safe_redirect( admin_url( 'options-general.php?page=pantheon-cache&cache-cleared=true' ) );
 			exit();
 		}
 	}
@@ -396,7 +405,7 @@ class Pantheon_Cache {
 	 * @param  int $post_id A post ID to clean.
 	 * @return void
 	 */
-	public function clean_post_cache( $post_id, $include_homepage = true ) {
+	public function clean_post_cache( $post_id, $include_homepage = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( method_exists( 'Pantheon_Advanced_Page_Cache\Purger', 'action_clean_post_cache' ) ) {
 			Pantheon_Advanced_Page_Cache\Purger::action_clean_post_cache( $post_id );
 		}
@@ -408,11 +417,11 @@ class Pantheon_Cache {
 	 *
 	 * @deprecated
 	 *
-	 * @param int|array $ids Single or list of Term IDs.
+	 * @param int|array $term_ids Single or list of Term IDs.
 	 * @param string $taxonomy Can be empty and will assume tt_ids, else will use for context.
 	 * @return void
 	 */
-	public function clean_term_cache( $term_ids, $taxonomy ) {
+	public function clean_term_cache( $term_ids, $taxonomy ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( method_exists( 'Pantheon_Advanced_Page_Cache\Purger', 'action_clean_term_cache' ) ) {
 			Pantheon_Advanced_Page_Cache\Purger::action_clean_term_cache( $term_ids );
 		}
@@ -428,8 +437,8 @@ class Pantheon_Cache {
 	 * @param array|string $object_type The taxonomy object type.
 	 * @return void
 	 */
-	public function clean_object_term_cache( $object_ids, $object_type ) {
-		// Handled by Pantheon Integrated CDN
+	public function clean_object_term_cache( $object_ids, $object_type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Handled by Pantheon Integrated CDN.
 	}
 
 	/**
@@ -439,30 +448,29 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function enqueue_urls( $urls ) {
-		$paths = array();
+		$paths = [];
 		$urls = array_filter( (array) $urls, 'is_string' );
 		foreach ( $urls as $full_url ) {
-			# Parse down to the path+query, escape regex.
+			// Parse down to the path+query, escape regex.
 			$parsed = parse_url( $full_url );
-			# Sometimes parse_url can return false, on malformed urls
-			if (FALSE == $parsed) {
+			// Sometimes parse_url can return false, on malformed urls.
+			if ( false === $parsed ) {
 				continue;
 			}
-			# Build up the path, checking if the array key exists first
-			if (array_key_exists('path', $parsed)) {
+			// Build up the path, checking if the array key exists first.
+			if ( array_key_exists( 'path', $parsed ) ) {
 				$path = $parsed['path'];
-				if (array_key_exists('query', $parsed))  {
+				if ( array_key_exists( 'query', $parsed ) ) {
 					$path = $path . $parsed['query'];
 				}
-			}
-			# If the path doesn't exist, set it to the null string
-			else {
+			} else {
+				// If the path doesn't exist, set it to the null string.
 				$path = '';
 			}
-			if ( '' == $path ) {
+			if ( '' === $path ) {
 				continue;
 			}
-			$path = '^' . preg_quote( $path ) . '$';
+			$path = '^' . preg_quote( $path ) . '$'; // phpcs:ignore WordPress.PHP.PregQuoteDelimiter.Missing
 			$paths[] = $path;
 		}
 
@@ -483,14 +491,13 @@ class Pantheon_Cache {
 
 
 	public function cache_clean_urls() {
-		if ( empty( $this->paths ) )
+		if ( empty( $this->paths ) ) {
 			return;
+		}
 
 		$this->paths = apply_filters( 'pantheon_clean_urls', array_unique( $this->paths ) );
 
-		# Call the big daddy here
-		$url = home_url();
-		$host = parse_url( $url, PHP_URL_HOST );
+		// Call the big daddy here.
 		$this->paths = apply_filters( 'pantheon_final_clean_urls', $this->paths );
 		if ( function_exists( 'pantheon_clear_edge_paths' ) ) {
 			pantheon_clear_edge_paths( $this->paths );
@@ -504,8 +511,6 @@ class Pantheon_Cache {
  * Get a reference to the singleton.
  *
  * This can be used to reference public methods, e.g. `Pantheon_Cache()->clean_post_cache( 123 )`
- *
- * @return void
  */
 function Pantheon_Cache() {
 	return Pantheon_Cache::instance();

--- a/inc/pantheon-plugin-install-notice.php
+++ b/inc/pantheon-plugin-install-notice.php
@@ -4,26 +4,26 @@
  */
 
 if ( ! wp_is_writable( WP_PLUGIN_DIR ) ) {
-    if ( ! defined( 'DISALLOW_FILE_MODS' ) ) {
-        define( 'DISALLOW_FILE_MODS', true );
-    }
+	if ( ! defined( 'DISALLOW_FILE_MODS' ) ) {
+		define( 'DISALLOW_FILE_MODS', true );
+	}
 
-    add_action( 'admin_notices', '_pantheon_plugin_install_notice' );
-    add_action( 'network_admin_notices', '_pantheon_plugin_install_notice' );
+	add_action( 'admin_notices', '_pantheon_plugin_install_notice' );
+	add_action( 'network_admin_notices', '_pantheon_plugin_install_notice' );
 }
 
 function _pantheon_plugin_install_notice() {
-    $screen = get_current_screen(); 
-    // Only show this notice on the plugins page.
-    if ( 'plugins' === $screen->id || 'plugins-network' === $screen->id ) { ?>
-        <div class="update-nag notice notice-warning is-dismissible" style="margin: 5px 6em 15px 0;">
-            <p style="font-size: 14px; margin: 0;">
-                <?php 
-                // Translators: %s is a URL to the user's Pantheon Dashboard.
-                echo wp_kses_post( sprintf( __( 'If you wish to update or add plugins using the WordPress UI, switch your site to SFTP mode from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) ); 
-                ?>
-            </p>
-        </div>
-        <?php
-    }
+	$screen = get_current_screen(); 
+	// Only show this notice on the plugins page.
+	if ( 'plugins' === $screen->id || 'plugins-network' === $screen->id ) { ?>
+		<div class="update-nag notice notice-warning is-dismissible" style="margin: 5px 6em 15px 0;">
+			<p style="font-size: 14px; margin: 0;">
+				<?php 
+				// Translators: %s is a URL to the user's Pantheon Dashboard.
+				echo wp_kses_post( sprintf( __( 'If you wish to update or add plugins using the WordPress UI, switch your site to SFTP mode from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) ); 
+				?>
+			</p>
+		</div>
+		<?php
+	}
 }

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -32,7 +32,7 @@ function _pantheon_hide_update_nag() {
  *
  * @return string
  */
-function _pantheon_get_current_wordpress_version() : string {
+function _pantheon_get_current_wordpress_version(): string {
 	include ABSPATH . WPINC . '/version.php';
 	return $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 }
@@ -42,7 +42,7 @@ function _pantheon_get_current_wordpress_version() : string {
  *
  * @return string|null
  */
-function _pantheon_get_latest_wordpress_version() : ?string {
+function _pantheon_get_latest_wordpress_version(): ?string {
 	$core_updates = get_core_updates();
 
 	if ( ! is_array( $core_updates ) || empty( $core_updates ) || ! property_exists( $core_updates[0], 'current' ) ) {
@@ -57,7 +57,7 @@ function _pantheon_get_latest_wordpress_version() : ?string {
  *
  * @return bool
  */
-function _pantheon_is_wordpress_core_latest() : bool {
+function _pantheon_is_wordpress_core_latest(): bool {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
 	$wp_version = _pantheon_get_current_wordpress_version();
 
@@ -67,7 +67,6 @@ function _pantheon_is_wordpress_core_latest() : bool {
 
 	// Return true if our version is the latest.
 	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '<=' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
 }
 
 /**
@@ -75,7 +74,7 @@ function _pantheon_is_wordpress_core_latest() : bool {
  *
  * @return bool
  */
-function _pantheon_is_wordpress_core_prerelease() : bool {
+function _pantheon_is_wordpress_core_prerelease(): bool {
 	$wp_version = _pantheon_get_current_wordpress_version();
 
 	// Return true if our version is a prerelease. Pre-releases are identified by a dash in the version number.
@@ -159,7 +158,7 @@ add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
  *
  * @return object
  */
-function _pantheon_disable_wp_updates() : object {
+function _pantheon_disable_wp_updates(): object {
 	$wp_version = _pantheon_get_current_wordpress_version();
 	return (object) [
 		'updates' => [],

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,12 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.0.0
+ * Version: 1.2.0
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
+
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.2.0' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 


### PR DESCRIPTION
* Updates Pantheon Mu Plugin to use Pantheon WP Coding Standards 2.0
* Fixes all the linting issues highlighted by the updated coding standards
* Adds a PANTHEON_MU_PLUGIN_VERSION constant and actually updates the mu-plugin version (which hasn't been done at all since it was added afaict)

**Todo**
- [x] There's no actual linting happening on the repo, we should add GH actions to at least cover linting (and maybe testing later)
- [ ] A new 1.2.0 release should be created after this is merged (we won't release until we know/understand how releases are handled via Updatinator and how the update will push out to pantheon-systems/WordPress).
- [x] we should add a contributing.md file since there are two places to bump versions now
- [x] we probably should add a .gitattributes file to exclude non-important files from releases (like the new phpcs.xml, GH actions, contributing, etc)
- [x] Prior to merge, we probably should make the changes in update-tool in case WP releases a patch _tomorrow_.