### PR TITLE
PHPUnit test updates for WP 6.4.1

### DIFF
--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -11,6 +11,8 @@
 class Test_Pantheon_Updates extends WP_UnitTestCase {
 	/**
 	 * The current WordPress version.
+	 * 
+	 * @var string
 	 */
 	private static $wp_version;
 


### PR DESCRIPTION
We can't get 100% away from hard-coding WP versions for things, but this gets us a little bit closer.

`_pantheon_get_current_wordpress_version` would need to be filterable to return anything other than the installed WordPress version. While we _could_ add a filter there, the only justification right now is filtering for tests. Given that the function is really for our own benefit anyway, that might actually provide some additional value for the function and is not be outside the realm of possibility, but I didn't want to push a change like that for the case of _just_ fixing tests.

The other change here is the addition of a new function that can dynamically generate a `-beta` version for the _next_ version of WordPress. These tests were failing because `6.4-beta` (which was hard-coded) was not newer than 6.4.1. the private method will take the current version (using `_pantheon_get_current_version`), bump it and add `-beta` so we can test with that when we run the pre-release test.