### PR TITLE
Remove hard-coded WP latest version check

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -45,6 +45,9 @@
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName">
 			<exclude-pattern>*/*</exclude-pattern>
 		</exclude>
+		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
+			<exclude-pattern>*/*</exclude-pattern>
+		</exclude>
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid">
 			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
 		</exclude>

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -5,16 +5,22 @@ set -e
 DIRNAME=$(dirname "$0")
 
 echo "🤔 Installing WP Unit tests..."
-bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
+bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest true
+
+echo "📄 Copying wp-latest.json..."
+cp /tmp/wp-latest.json "${DIRNAME}/../tests/wp-latest.json"
 
 echo "🏃‍♂️ Running PHPUnit on Single Site"
 composer phpunit --ansi
 
 echo "🧹 Removing files before testing nightly WP..."
 rm -rf "$WP_TESTS_DIR" "$WP_CORE_DIR"
+rm "${DIRNAME}/../tests/wp-latest.json"
 
 echo "🤔 Installing WP Unit tests with WP nightly version..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 nightly true
+echo "📄 Copying wp-latest.json..."
+cp /tmp/wp-latest.json "${DIRNAME}/../tests/wp-latest.json"
 echo "🏃‍♂️ Running PHPUnit on Single Site (Nightly WordPress)"
 composer phpunit --ansi
 

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -5,7 +5,7 @@ set -e
 DIRNAME=$(dirname "$0")
 
 echo "🤔 Installing WP Unit tests..."
-bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest true
+bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 
 echo "📄 Copying wp-latest.json..."
 cp /tmp/wp-latest.json "${DIRNAME}/../tests/wp-latest.json"

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -31,7 +31,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	 */
 	private static function get_latest_wp_version_from_file() {
 		$file = dirname( __DIR__ ) . '/wp-latest.json';
-		// var_dump($file);
+
 		if ( ! file_exists( $file ) ) {
 			return false;
 		}

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -25,6 +25,24 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Get the latest WordPress version from the wp-latest.json file.
+	 * 
+	 * @return string|bool The latest WordPress version or false if the file doesn't exist.
+	 */
+	private static function get_latest_wp_version_from_file() {
+		$file = dirname( __DIR__ ) . '/wp-latest.json';
+		// var_dump($file);
+		if ( ! file_exists( $file ) ) {
+			return false;
+		}
+
+		$version_raw = json_decode( file_get_contents( $file ) );
+		$version = $version_raw->offers[0]->current;
+
+		return $version;
+	}
+
+	/**
 	 * Test the _pantheon_hide_update_nag function.
 	 */
 	public function test_pantheon_hide_update_nag() {

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -64,9 +64,10 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	public function test_pantheon_get_current_wordpress_version() {
 		// Run the function.
 		$result = _pantheon_get_current_wordpress_version();
+		$current_version = self::get_latest_wp_version_from_file();
 
 		// Check that the returned version is correct. This value needs to be changed when the WordPress version is updated.
-		$this->assertEquals( '6.4.1', $result );
+		$this->assertEquals( $current_version, $result );
 	}
 
 	/**


### PR DESCRIPTION
This pull request updates the WP version handling and testing in the codebase. It includes the following changes:

- Copies the `wp-latest.json` file from the `tmp` directory into the `tests` directory. This allows us to validate against the version of WP that WP is reporting for itself and remove the hard-coded versions.

- Adds a helper method that gets the WP version from `wp-latest.json`.

- Uses the version stored in `wp-latest.json` for testing.

These changes improve the accuracy and flexibility of WP version handling in the codebase.

This will fix the currently failing tests.

