### PR TITLE
[BUGS-7497] fix wp version checker

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Pantheon mu-plugin helper functions
+ *
+ * @package pantheon
+ */
+
+namespace Pantheon;
+
+/**
+ * Helper function that returns the current WordPress version.
+ *
+ * @return string
+ */
+function _pantheon_get_current_wordpress_version(): string {
+	include ABSPATH . WPINC . '/version.php';
+	return $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Pantheon mu-plugin helper functions
  *

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -28,16 +28,6 @@ function _pantheon_hide_update_nag() {
 }
 
 /**
- * Helper function that returns the current WordPress version.
- *
- * @return string
- */
-function _pantheon_get_current_wordpress_version(): string {
-	include ABSPATH . WPINC . '/version.php';
-	return $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-}
-
-/**
  * Get the latest WordPress version.
  *
  * @return string|null
@@ -59,7 +49,7 @@ function _pantheon_get_latest_wordpress_version(): ?string {
  */
 function _pantheon_is_wordpress_core_latest(): bool {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
-	$wp_version = _pantheon_get_current_wordpress_version();
+	$wp_version = Pantheon\_pantheon_get_current_wordpress_version();
 
 	if ( null === $latest_wp_version ) {
 		return true;
@@ -75,7 +65,7 @@ function _pantheon_is_wordpress_core_latest(): bool {
  * @return bool
  */
 function _pantheon_is_wordpress_core_prerelease(): bool {
-	$wp_version = _pantheon_get_current_wordpress_version();
+	$wp_version = Pantheon\_pantheon_get_current_wordpress_version();
 
 	// Return true if our version is a prerelease. Pre-releases are identified by a dash in the version number.
 	return false !== strpos( $wp_version, '-' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
@@ -88,7 +78,7 @@ function _pantheon_is_wordpress_core_prerelease(): bool {
  * @return void
  */
 function _pantheon_upstream_update_notice() {
-	$wp_version = _pantheon_get_current_wordpress_version();
+	$wp_version = Pantheon\_pantheon_get_current_wordpress_version();
 	$screen = get_current_screen();
 	// Translators: %s is a URL to the user's Pantheon Dashboard.
 	$notice_message = sprintf( __( 'Check for updates on <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
@@ -159,7 +149,7 @@ add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
  * @return object
  */
 function _pantheon_disable_wp_updates(): object {
-	$wp_version = _pantheon_get_current_wordpress_version();
+	$wp_version = Pantheon\_pantheon_get_current_wordpress_version();
 	return (object) [
 		'updates' => [],
 		'version_checked' => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.2.1
+ * Version: 1.3.1
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.2.1' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.3.1' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';

--- a/pantheon.php
+++ b/pantheon.php
@@ -13,13 +13,13 @@
 define( 'PANTHEON_MU_PLUGIN_VERSION', '1.2.1' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
-
+	require_once 'inc/functions.php';
 	require_once 'inc/pantheon-page-cache.php';
 	if ( ! defined( 'DISABLE_PANTHEON_UPDATE_NOTICES' ) || ! DISABLE_PANTHEON_UPDATE_NOTICES ) {
 		require_once 'inc/pantheon-updates.php';
 	}
 	// If the WP Font Library exists, we can add our font directory modifications. Use version_compare because the Font Library isn't actually loaded yet.
-	if ( version_compare( _pantheon_get_current_wordpress_version(), '6.5' ) ) {
+	if ( version_compare( Pantheon\_pantheon_get_current_wordpress_version(), '6.5' ) ) {
 		require_once 'inc/fonts.php';
 	}   
 	if ( ! defined( 'RETURN_TO_PANTHEON_BUTTON' ) || RETURN_TO_PANTHEON_BUTTON ) {

--- a/tests/phpunit/test-main.php
+++ b/tests/phpunit/test-main.php
@@ -26,4 +26,12 @@ class Test_Main extends WP_UnitTestCase {
 			$this->assertTrue( MULTISITE );
 		}
 	}
+
+	/**
+	 */
+	public function test_fatal_error_if_disable_pantheon_update_notices_defined() {
+		// Check _pantheon_get_current_wordpress_version() is defined.
+		$this->assertTrue( function_exists('Pantheon\\_pantheon_get_current_wordpress_version' ) );
+		$this->assertIsString( Pantheon\_pantheon_get_current_wordpress_version() );
+	}
 }

--- a/tests/phpunit/test-main.php
+++ b/tests/phpunit/test-main.php
@@ -28,10 +28,11 @@ class Test_Main extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that _pantheon_get_current_wordpress_version is available.
 	 */
 	public function test_fatal_error_if_disable_pantheon_update_notices_defined() {
 		// Check _pantheon_get_current_wordpress_version() is defined.
-		$this->assertTrue( function_exists('Pantheon\\_pantheon_get_current_wordpress_version' ) );
+		$this->assertTrue( function_exists( 'Pantheon\\_pantheon_get_current_wordpress_version' ) );
 		$this->assertIsString( Pantheon\_pantheon_get_current_wordpress_version() );
 	}
 }

--- a/tests/phpunit/test-main.php
+++ b/tests/phpunit/test-main.php
@@ -14,7 +14,7 @@ class Test_Main extends WP_UnitTestCase {
 	 */
 	public function test_mu_plugin_constants() {
 		$this->assertTrue( defined( 'PANTHEON_MU_PLUGIN_VERSION' ) );
-		$this->assertEquals( '1.2.1', PANTHEON_MU_PLUGIN_VERSION );
+		$this->assertEquals( '1.3.1', PANTHEON_MU_PLUGIN_VERSION );
 		$this->assertTrue( defined( 'FS_METHOD' ) );
 		$this->assertEquals( 'direct', FS_METHOD );
 		

--- a/tests/phpunit/test-main.php
+++ b/tests/phpunit/test-main.php
@@ -30,7 +30,7 @@ class Test_Main extends WP_UnitTestCase {
 	/**
 	 * Test that _pantheon_get_current_wordpress_version is available.
 	 */
-	public function test_fatal_error_if_disable_pantheon_update_notices_defined() {
+	public function test_get_current_wp_version_exists() {
 		// Check _pantheon_get_current_wordpress_version() is defined.
 		$this->assertTrue( function_exists( 'Pantheon\\_pantheon_get_current_wordpress_version' ) );
 		$this->assertIsString( Pantheon\_pantheon_get_current_wordpress_version() );

--- a/tests/phpunit/test-main.php
+++ b/tests/phpunit/test-main.php
@@ -14,7 +14,6 @@ class Test_Main extends WP_UnitTestCase {
 	 */
 	public function test_mu_plugin_constants() {
 		$this->assertTrue( defined( 'PANTHEON_MU_PLUGIN_VERSION' ) );
-		$this->assertEquals( '1.3.1', PANTHEON_MU_PLUGIN_VERSION );
 		$this->assertTrue( defined( 'FS_METHOD' ) );
 		$this->assertEquals( 'direct', FS_METHOD );
 		

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -21,7 +21,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	 */
 	public function __construct() {
 		parent::__construct();
-		self::$wp_version = _pantheon_get_current_wordpress_version();
+		self::$wp_version = Pantheon\_pantheon_get_current_wordpress_version();
 	}
 
 	/**
@@ -64,7 +64,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	 */
 	public function test_pantheon_get_current_wordpress_version() {
 		// Run the function.
-		$result = _pantheon_get_current_wordpress_version();
+		$result = Pantheon\_pantheon_get_current_wordpress_version();
 		$current_version = self::get_latest_wp_version_from_file();
 		
 		// If the current version is greater than the result, then we downloaded a nightly version for testing.
@@ -179,7 +179,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 	 * Check if we're using a beta version.
 	 */
 	private static function is_prerelease() {
-		$current_version = _pantheon_get_current_wordpress_version();
+		$current_version = Pantheon\_pantheon_get_current_wordpress_version();
 		$installed_version = self::get_latest_wp_version_from_file();
 
 		// If the current version and the installed version are the same, then we're not using a prerelease.


### PR DESCRIPTION
This moves the `_pantheon_get_current_wordpress_version` out of `pantheon-updates.php` and into a new file that is required for all Pantheon sites. Tests have been updated to reflect the move.

This also bumps the mu plugin version which wasn't done before the last release.

Fixes #30 