### PR TITLE
[CMSP-695] Remove override for `font_dir` filter

### DIFF
--- a/inc/fonts.php
+++ b/inc/fonts.php
@@ -21,21 +21,8 @@ $_pantheon_upload_dir = wp_get_upload_dir(); // phpcs:ignore VariableAnalysis.Co
  * Kick off our customizations to the WP_Font_Library.
  */
 function bootstrap() {
-	/**
-	 * Modify the fonts directory.
-	 *
-	 * By default, this is set to true, so we can override the default fonts directory from wp-content/fonts to wp-content/uploads/fonts.
-	 *
-	 * Use the filter to set to false and use the default WordPress behavior (committing fonts to your repository and pushing from dev -> test -> live).
-	 *
-	 * @param bool $modify_fonts_dir Whether to modify the fonts directory.
-	 */
-	$modify_fonts_dir = apply_filters( 'pantheon_modify_fonts_dir', true );
-
-	if ( $modify_fonts_dir ) {
-		// Use the new font_dir filter added in WordPress 6.5. See https://github.com/WordPress/gutenberg/pull/57697.
-		add_filter( 'font_dir', __NAMESPACE__ . '\\pantheon_font_dir', 9 );
-	}
+	// Use the new font_dir filter added in WordPress 6.5. See https://github.com/WordPress/gutenberg/pull/57697.
+	add_filter( 'font_dir', __NAMESPACE__ . '\\pantheon_font_dir', 9 );
 }
 add_action( 'init', __NAMESPACE__ . '\\bootstrap' );
 

--- a/tests/phpunit/test-fonts.php
+++ b/tests/phpunit/test-fonts.php
@@ -24,7 +24,6 @@ class Test_Fonts extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		remove_all_filters( 'font_dir' );
-		remove_all_filters( 'pantheon_modify_fonts_dir' );
 
 		// Mock the global variable before each test.
 		global $_pantheon_upload_dir;
@@ -141,35 +140,6 @@ class Test_Fonts extends WP_UnitTestCase {
 			'subdir' => '',
 			'basedir' => WP_CONTENT_DIR . '/custom-fonts',
 			'baseurl' => WP_CONTENT_URL . '/custom-fonts',
-			'error' => false,
-		];
-
-		$this->assertEquals( $expected, $font_dir );
-	}
-
-	/**
-	 * Test that the font directory modifications can be disabled.
-	 */
-	public function test_disable_pantheon_font_dir_mods() {
-		$this->maybe_get_font_library();
-		if ( ! function_exists( 'wp_get_font_dir' ) ) {
-			// If the function still doesn't exist after trying to get the font library from gutenberg, mark the test skipped.
-			$this->markTestSkipped( 'The wp_get_font_dir function is not available. We\'re probably not using WP 6.5+' );
-		}
-
-		// Disable the font directory modifications.
-		add_filter( 'pantheon_modify_fonts_dir', '__return_false' );
-		$modify_fonts_dir = apply_filters( 'pantheon_modify_fonts_dir', true );
-		$this->assertFalse( $modify_fonts_dir );
-
-		$font_dir = wp_get_font_dir();
-
-		$expected = [
-			'path' => WP_CONTENT_DIR . '/fonts',
-			'url' => WP_CONTENT_URL . '/fonts',
-			'subdir' => '',
-			'basedir' => WP_CONTENT_DIR . '/fonts',
-			'baseurl' => WP_CONTENT_URL . '/fonts',
 			'error' => false,
 		];
 


### PR DESCRIPTION
Given that it seems like fonts are considered to be more like media files than themes or plugins, it would be undesirable to commit fonts to the repository, so we don't need our override to the WordPress core behavior.

This PR removes the override.  

See https://github.com/pantheon-systems/documentation/pull/8867

Follows #29.