### PR TITLE
[CMSP-899] Remove our global for the `upload_dir` infinite loop

### DIFF
--- a/inc/fonts.php
+++ b/inc/fonts.php
@@ -8,16 +8,6 @@
 namespace Pantheon\Fonts;
 
 /**
- * Store the value of wp_get_upload_dir() in a global variable.
- * This is to resolve an infinite loop when wp_get_upload_dir is used inside
- * our filter of font_dir (because upload_dir is also being filtered).
- *
- * @var array $wp_upload_dir The value of wp_get_upload_dir().
- * @see https://developer.wordpress.org/reference/functions/wp_get_upload_dir/
- */
-$_pantheon_upload_dir = wp_get_upload_dir(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-/**
  * Kick off our customizations to the WP_Font_Library.
  */
 function bootstrap() {
@@ -33,10 +23,11 @@ add_action( 'init', __NAMESPACE__ . '\\bootstrap' );
  * @param array $defaults The default settings for the font directory.
  */
 function pantheon_font_dir( $defaults ) {
-	global $_pantheon_upload_dir;
+	$upload_dir = wp_get_upload_dir();
+
 	// Set our font directory.
-	$font_dir = $_pantheon_upload_dir['basedir'] . '/fonts';
-	$font_url = $_pantheon_upload_dir['baseurl'] . '/fonts';
+	$font_dir = $upload_dir['basedir'] . '/fonts';
+	$font_url = $upload_dir['baseurl'] . '/fonts';
 
 	$defaults['path'] = $font_dir;
 	$defaults['url'] = $font_url;


### PR DESCRIPTION
Per https://github.com/WordPress/gutenberg/pull/58839 the issue causing the infinite loop when `upload_dir` is used inside `font_dir` should be addressed.

This change removes our workaround for that issue and uses `wp_get_upload_dir` directly in the `font_dir` folder.

**Note:** While these changes have been merged into Gutenberg, they have not yet been merged into core or made part of the latest Gutenberg release. This should not be merged until this can be tested and confirmed working (PHP Unit tests are not sufficient).

**Todo:**
- [x] Testing against latest core/Gutenberg