### PR TITLE
[CMSP-991 CMSP-993] Bump default cache TTL and add filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,81 @@ What does that mean? We're glad you asked!
 ### Maintenance Mode
 **Put your site into a maintenance mode.** Prevent users from accessing your sites during major updates by enabling Maintenance Mode either in the WordPress admin or via WP-CLI.
 
+## Hooks
+
+The Pantheon Must-Use Plugin provides the following hooks that can be used in your code:
+
+### Filters
+
+#### `pantheon_wp_login_text`
+Filter the text displayed on the login page next to the Return to Pantheon button.
+
+**Default Value:** `Log into your WordPress Site`
+
+**Example:**
+```php
+add_filter( 'pantheon_wp_login_text', function() {
+	return 'Log into MySite.';
+} );
+```
+
+#### `pantheon_cache_default_ttl`
+Filter the default cache age for the Pantheon Edge Cache.
+
+**Default Value:** `WEEK_IN_SECONDS` (604800)
+
+**Example:**
+```php
+add_filter( 'pantheon_cache_default_ttl', function() {
+    return 2 * WEEK_IN_SECONDS;
+} );
+```
+
+#### `pantheon_cache_do_maintenance_mode`
+Allows you to modify the maintenance mode behavior with more advanced conditionals.
+
+**Default Value:** Boolean, depending on whether maintenance mode is enabled, user is not on the login page and the action is not happening in WP-CLI.
+
+```php
+add_filter( 'pantheon_cache_do_maintenance_mode', function( $do_maintenance_mode ) {
+	if ( $some_conditional_logic ) {
+		return false;
+	}
+	return $do_maintenance_mode;
+} );
+```
+
+#### `pantheon_cache_allow_clear_all`
+Allows you to disable the ability to clear the entire cache from the WordPress admin. If set to `false`, this removes the "Clear Site Cache" section of the Pantheon Page Cache admin page.
+
+**Default Value:** `true`
+
+**Example:**
+```php
+add_filter( 'pantheon_cache_allow_clear_all', '__return_false' );
+```
+
+### Actions
+#### `pantheon_cache_settings_page_top`
+Runs at the top of the Pantheon Page Cache settings page.
+
+**Example:**
+```php
+add_action( 'pantheon_cache_settings_page_top', function() {
+	echo '<h2>My Custom Heading</h2>';
+} );
+```
+
+#### `pantheon_cache_settings_page_bottom`
+Runs at the bottom of the Pantheon Page Cache settings page.
+
+**Example:**
+```php
+add_action( 'pantheon_cache_settings_page_bottom', function() {
+	echo '<p>My Custom Footer</p>';
+} );
+```
+
 ## Install With Composer
 **Built for Composer.** While Pantheon automation ensures that the latest version of the MU plugin are pushed with every update to WordPress, the Composer-based project ensures that you can manage it alongside your other WordPress mu-plugins, plugins and themes in your `composer.json`.
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@ The Pantheon Must-Use Plugin has been designed to tailor the WordPress CMS exper
 
 What does that mean? We're glad you asked!
 
-## WebOps Workflow
+## Features
+
+### WebOps Workflow
 **Integrates WordPress with Pantheon Worklow.** Encourages updating plugins and themes in the Development environment and using Pantheon's git-based upstream core updates. Alerts admins if an update is available but disables automatic updates (so those updates can be applied via the upstream).
 
-## Login
+### Login
 **Customized login form.** The login page links back to the Pantheon dashboard on dev, test and live environments that do not have a domain attached.
 
-## Edge Cache (Global CDN)
+### Edge Cache (Global CDN)
 **Facilitates communication between Pantheon's Edge Cache layer and WordPress.** It allows you to set the default cache age, clear individual pages on demand, and it will automatically clear relevant urls when the site is updated. Authored by [Matthew Boynes](http://www.alleyinteractive.com/).
 
-## WordPress Multisite Support
+### WordPress Multisite Support
 **Simplified multisite configuration.** The `WP_ALLOW_MULTISITE` is automatically defined on WordPress Multisite-based upstreams. The Network Setup pages and notices have been customized for a Pantheon-specific WordPress multisite experience.
 
-## Maintenance Mode
+### Maintenance Mode
 **Put your site into a maintenance mode.** Prevent users from accessing your sites during major updates by enabling Maintenance Mode either in the WordPress admin or via WP-CLI.
 
 ## Install With Composer

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -90,10 +90,10 @@ class Pantheon_Cache {
 		/**
 		 * Modify the default TTL for the Pantheon cache. Defaults to 1 week.
 		 *
-		 * usage:
-		 * 	add_filter( 'pantheon_cache_default_ttl', function() {
-		 * 		return DAY_IN_SECONDS;
-		 * 	} );
+		 * Usage:
+		 *  add_filter( 'pantheon_cache_default_ttl', function() {
+		 *      return DAY_IN_SECONDS;
+		 *  } );
 		 *
 		 * @param int $default_ttl The default TTL in seconds.
 		 */

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -87,9 +87,21 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	protected function setup() {
+		/**
+		 * Modify the default TTL for the Pantheon cache. Defaults to 1 week.
+		 *
+		 * usage:
+		 * 	add_filter( 'pantheon_cache_default_ttl', function() {
+		 * 		return DAY_IN_SECONDS;
+		 * 	} );
+		 *
+		 * @param int $default_ttl The default TTL in seconds.
+		 */
+		$default_ttl = apply_filters( 'pantheon_cache_default_ttl', WEEK_IN_SECONDS );
+
 		$this->options = get_option( self::SLUG, [] );
 		$this->default_options = [
-			'default_ttl' => 600,
+			'default_ttl' => $default_ttl,
 			'maintenance_mode' => 'disabled',
 		];
 		$this->options = wp_parse_args( $this->options, $this->default_options );

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -226,9 +226,15 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function default_ttl_field() {
+		$disabled = ( has_filter( 'pantheon_cache_default_ttl' ) ) ? ' disabled' : '';
 		echo '<h3>' . esc_html__( 'Default Time to Live (TTL)', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher TTL typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" ' . $disabled . ' /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+		// Display a message if the setting is disabled.
+		if ( $disabled ) {
+			echo '<p>' . esc_html__( 'This setting is disabled because the default TTL has been filtered to the current value.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 	}
 
 	/**

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.3.4
+ * Version: 1.4.0
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.3.4' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.0' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -198,7 +198,7 @@ class Test_Page_Cache extends WP_UnitTestCase {
 	 */
 	public function test_pantheon_cache_default_ttl_filter() {
 		// Add a filter to change the default TTL to 120 seconds.
-		add_filter( 'pantheon_cache_default_ttl', function() {
+		add_filter( 'pantheon_cache_default_ttl', function () {
 			return 120;
 		} );
 

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -30,7 +30,7 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		parent::setUp();
 		$this->pantheon_cache = Pantheon_Cache::instance();
 		$this->default_options = [
-			'default_ttl' => 600,
+			'default_ttl' => 60*60*24*7, // 1 week.
 			'maintenance_mode' => 'disabled',
 		];
 		$this->pantheon_cache->paths = []; // Clear any leftover paths.

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -30,7 +30,7 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		parent::setUp();
 		$this->pantheon_cache = Pantheon_Cache::instance();
 		$this->default_options = [
-			'default_ttl' => 60*60*24*7, // 1 week.
+			'default_ttl' => 60 * 60 * 24 * 7, // 1 week.
 			'maintenance_mode' => 'disabled',
 		];
 		$this->pantheon_cache->paths = []; // Clear any leftover paths.

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -192,4 +192,23 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		// Now the paths array should contain both regexes.
 		$this->assertEquals( [ $regex, $another_regex ], $this->pantheon_cache->paths );
 	}
+
+	/**
+	 * Test the filtered value and display if the pantheon_cache_default_ttl filter is used.
+	 */
+	public function test_pantheon_cache_default_ttl_filter() {
+		// Add a filter to change the default TTL to 120 seconds.
+		add_filter( 'pantheon_cache_default_ttl', function() {
+			return 120;
+		} );
+
+		// Get the filtered default TTL.
+		$filtered_default_ttl = apply_filters( 'pantheon_cache_default_ttl', get_option( 'default_ttl' ) );
+
+		// The filtered default TTL should be 120 seconds.
+		$this->assertEquals( 120, $filtered_default_ttl );
+
+		// Remove the filter.
+		remove_all_filters( 'pantheon_cache_default_ttl' );
+	}
 }


### PR DESCRIPTION
Updates the default cache TTL and adds a new `pantheon_cache_default_ttl` filter.
Adds documentation for the filter (and all the other hooks in the mu-plugin) to the README.md file.
Updates tests with new TTL value as well as adds tests for the filter.
Adds functionality that disables the input value if the filter is used.

Using the default value:
<img width="622" alt="Screenshot 2024-04-19 at 1 24 46 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/8578186d-0476-4366-844a-79a559bf2b3b">

Using the filter:
<img width="602" alt="Screenshot 2024-04-19 at 2 16 32 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/d07191a2-3350-4987-831c-d1292ae96326">

