### PR TITLE
[BUGS-6639] site health checks

### DIFF
--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -1,0 +1,28 @@
+<?php
+<?php
+/**
+ * Pantheon Site Health Modifications
+ *
+ * @package pantheon
+ */
+
+namespace Pantheon\Site_Health;
+
+// If on Pantheon...
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+	add_filter( 'site_status_tests', __NAMESPACE__ . '\\site_health_mods' );
+}
+
+/**
+ * Modify the Site Health tests.
+ *
+ * @param array $tests The Site Health tests.
+ * @return array
+ */
+function site_health_mods( $tests ) {
+	// Remove checks that aren't relevant to Pantheon environments.
+    unset( $tests['direct']['update_temp_backup_writable'] );
+    unset( $tests['direct']['available_updates_disk_space'] );
+    unset( $tests['async']['background_updates'] );
+	return $tests;
+}

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -85,7 +85,11 @@ function test_object_cache() {
 			),
 			'test' => 'object_cache',
 		];
-	} elseif ( $ocp_active ) {
+
+		return $result;
+	}
+
+	if ( $ocp_active ) {
 		$result = [
 			'label' => __( 'Object Cache Pro Active', 'pantheon' ),
 			'status' => 'good',
@@ -101,23 +105,25 @@ function test_object_cache() {
 			),
 			'test' => 'object_cache',
 		];
-	} else {
-		$result = [
-			'label' => __( 'No Object Cache Plugin Active', 'pantheon' ),
-			'status' => 'critical',
-			'badge' => [
-				'label' => __( 'Performance', 'pantheon' ),
-				'color' => 'red',
-			],
-			'description' => sprintf(
-				'<p>%s</p><p>%s</p>',
-				__( 'Redis object cache is active for your site but you have no object cache plugin installed. We recommend using Object Cache Pro.', 'pantheon' ),
-				// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
-				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
-			),
-			'test' => 'object_cache',
-		];
+
+		return $result;
 	}
+
+	$result = [
+		'label' => __( 'No Object Cache Plugin Active', 'pantheon' ),
+		'status' => 'critical',
+		'badge' => [
+			'label' => __( 'Performance', 'pantheon' ),
+			'color' => 'red',
+		],
+		'description' => sprintf(
+			'<p>%s</p><p>%s</p>',
+			__( 'Redis object cache is active for your site but you have no object cache plugin installed. We recommend using Object Cache Pro.', 'pantheon' ),
+			// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
+			sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
+		),
+		'test' => 'object_cache',
+	];
 
 	return $result;
 }

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -60,6 +60,7 @@ function test_object_cache() {
 				'<p>%s</p>',
 				__( 'Redis object cache is not active for your site.', 'pantheon' )
 			),
+			'test' => 'object_cache',
 		];
 
 		return $result;
@@ -82,6 +83,7 @@ function test_object_cache() {
 				// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
 				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
 			),
+			'test' => 'object_cache',
 		];
 	} elseif ( $ocp_active ) {
 		$result = [
@@ -97,6 +99,7 @@ function test_object_cache() {
 				// Translators: %s is a URL to the Object Cache Pro documentation.
 				sprintf( __( 'Visit the <a href="%s">Object Cache Pro</a> documentation to learn more.', 'pantheon' ), 'https://objectcache.pro/docs' )
 			),
+			'test' => 'object_cache',
 		];
 	} else {
 		$result = [
@@ -112,6 +115,7 @@ function test_object_cache() {
 				// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
 				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
 			),
+			'test' => 'object_cache',
 		];
 	}
 

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -83,7 +83,7 @@ function test_object_cache() {
 				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
 			),
 		];
-	} else {
+	} elseif ( $ocp_active ){
 		$result = [
 			'label' => __( 'Object Cache Pro Active', 'pantheon' ),
 			'status' => 'good',
@@ -95,6 +95,20 @@ function test_object_cache() {
 				'<p>%s</p><p>%s</p>',
 				__( 'Object Cache Pro is active for your site.', 'pantheon' ),
 				sprintf( __( 'Visit the <a href="%s">Object Cache Pro</a> documentation to learn more.', 'pantheon' ), 'https://objectcache.pro/docs' )
+			),
+		];
+	} else {
+		$result = [
+			'label' => __( 'No Object Cache Plugin Active', 'pantheon' ),
+			'status' => 'critical',
+			'badge' => [
+				'label' => __( 'Performance', 'pantheon' ),
+				'color' => 'red',
+			],
+			'description' => sprintf(
+				'<p>%s</p><p>%s</p>',
+				__( 'Redis object cache is active for your site but you have no object cache plugin installed. We recommend using Object Cache Pro.', 'pantheon' ),
+				sprintf(__('Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon'), 'https://docs.pantheon.io/object-cache/wordpress')
 			),
 		];
 	}

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -74,7 +74,7 @@ function test_object_cache() {
 			'status' => 'recommended',
 			'badge' => [
 				'label' => __( 'Performance', 'pantheon' ),
-				'color' => 'yellow',
+				'color' => 'orange',
 			],
 			'description' => sprintf(
 				'<p>%s</p><p>%s</p>',

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -1,5 +1,4 @@
 <?php
-<?php
 /**
  * Pantheon Site Health Modifications
  *
@@ -22,9 +21,9 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
  */
 function site_health_mods( $tests ) {
 	// Remove checks that aren't relevant to Pantheon environments.
-    unset( $tests['direct']['update_temp_backup_writable'] );
-    unset( $tests['direct']['available_updates_disk_space'] );
-    unset( $tests['async']['background_updates'] );
+	unset( $tests['direct']['update_temp_backup_writable'] );
+	unset( $tests['direct']['available_updates_disk_space'] );
+	unset( $tests['async']['background_updates'] );
 	return $tests;
 }
 
@@ -80,10 +79,11 @@ function test_object_cache() {
 			'description' => sprintf(
 				'<p>%s</p><p>%s</p>',
 				__( 'WP Redis is active for your site. We recommend using Object Cache Pro.', 'pantheon' ),
+				// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
 				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
 			),
 		];
-	} elseif ( $ocp_active ){
+	} elseif ( $ocp_active ) {
 		$result = [
 			'label' => __( 'Object Cache Pro Active', 'pantheon' ),
 			'status' => 'good',
@@ -94,6 +94,7 @@ function test_object_cache() {
 			'description' => sprintf(
 				'<p>%s</p><p>%s</p>',
 				__( 'Object Cache Pro is active for your site.', 'pantheon' ),
+				// Translators: %s is a URL to the Object Cache Pro documentation.
 				sprintf( __( 'Visit the <a href="%s">Object Cache Pro</a> documentation to learn more.', 'pantheon' ), 'https://objectcache.pro/docs' )
 			),
 		];
@@ -108,7 +109,8 @@ function test_object_cache() {
 			'description' => sprintf(
 				'<p>%s</p><p>%s</p>',
 				__( 'Redis object cache is active for your site but you have no object cache plugin installed. We recommend using Object Cache Pro.', 'pantheon' ),
-				sprintf(__('Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon'), 'https://docs.pantheon.io/object-cache/wordpress')
+				// Translators: %s is a URL to the Pantheon documentation to install Object Cache Pro.
+				sprintf( __( 'Visit our <a href="%s">documentation site</a> to learn how to install it.', 'pantheon' ), 'https://docs.pantheon.io/object-cache/wordpress' )
 			),
 		];
 	}

--- a/pantheon.php
+++ b/pantheon.php
@@ -15,6 +15,7 @@ define( 'PANTHEON_MU_PLUGIN_VERSION', '1.3.4' );
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';
 	require_once 'inc/pantheon-page-cache.php';
+	require_once 'inc/site-health.php';
 	if ( ! defined( 'DISABLE_PANTHEON_UPDATE_NOTICES' ) || ! DISABLE_PANTHEON_UPDATE_NOTICES ) {
 		require_once 'inc/pantheon-updates.php';
 	}

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Pantheon Site Health page Tests
+ * 
+ * @package pantheon
+ */
+
+class Test_Site_Health extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		// Attach the site_health_mods function to the 'site_status_tests' filter
+		add_filter('site_status_tests', '\\Pantheon\\Site_Health\\site_health_mods');
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		// Remove the site_health_mods function from the 'site_status_tests' filter to clean up
+		remove_filter('site_status_tests', '\\Pantheon\\Site_Health\\site_health_mods');
+	}
+
+	public function test_site_health_mods() {
+		// Mock array to represent the structure passed to the filter
+		$mock_tests = [
+			'direct' => [
+				'update_temp_backup_writable' => [],
+				'available_updates_disk_space' => [],
+			],
+			'async' => [
+				'background_updates' => [],
+			],
+		];
+
+		// Apply the filter, which will now use your attached function
+		$result = apply_filters('site_status_tests', $mock_tests);
+
+		// Assertions to verify the modifications made by your function
+		$this->assertArrayNotHasKey('update_temp_backup_writable', $result['direct']);
+		$this->assertArrayNotHasKey('available_updates_disk_space', $result['direct']);
+		$this->assertArrayNotHasKey('background_updates', $result['async']);
+	}
+}

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -1,12 +1,21 @@
 <?php
-
 /**
  * Pantheon Site Health page Tests
  * 
  * @package pantheon
  */
 
+/**
+ * Pantheon Site Health page Test Case
+ */
 class Test_Site_Health extends WP_UnitTestCase {
+	/**
+	 * The original active plugins.
+	 * 
+	 * Used to restore the original active plugins after the test.
+	 *
+	 * @var array
+	 */
 	private $original_active_plugins;
 
 	public function setUp(): void {
@@ -27,7 +36,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_site_health_mods() {
-		// Mock array to represent the structure passed to the filter
+		// Mock array to represent the structure passed to the filter.
 		$mock_tests = [
 			'direct' => [
 				'update_temp_backup_writable' => [],
@@ -40,9 +49,9 @@ class Test_Site_Health extends WP_UnitTestCase {
 
 		$result = apply_filters( 'site_status_tests', $mock_tests );
 
-		$this->assertArrayNotHasKey('update_temp_backup_writable', $result['direct']);
-		$this->assertArrayNotHasKey('available_updates_disk_space', $result['direct']);
-		$this->assertArrayNotHasKey('background_updates', $result['async']);
+		$this->assertArrayNotHasKey( 'update_temp_backup_writable', $result['direct'] );
+		$this->assertArrayNotHasKey( 'available_updates_disk_space', $result['direct'] );
+		$this->assertArrayNotHasKey( 'background_updates', $result['async'] );
 	}
 
 	public function test_object_cache_no_redis() {
@@ -53,8 +62,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_redis_no_plugin() {
-		// Mock the environment for this scenario
-		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set
+		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 
 		$result = Pantheon\Site_Health\test_object_cache();
 
@@ -63,22 +71,22 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_wpredis_active() {
-		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set
+		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'wp-redis/wp-redis.php' );
 
 		$result = Pantheon\Site_Health\test_object_cache();
 
 		$this->assertEquals( 'recommended', $result['status'] );
-		$this->assertStringContainsString('WP Redis is active for your site. We recommend using Object Cache Pro.', $result['description'] );
+		$this->assertStringContainsString( 'WP Redis is active for your site. We recommend using Object Cache Pro.', $result['description'] );
 	}
 
 	public function test_object_cache_with_ocp_active() {
-		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set
+		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'object-cache-pro/object-cache-pro.php' );
 
 		$result = Pantheon\Site_Health\test_object_cache();
 
 		$this->assertEquals( 'good', $result['status'] );
-		$this->assertStringContainsString('Object Cache Pro is active for your site.', $result['description'] );
+		$this->assertStringContainsString( 'Object Cache Pro is active for your site.', $result['description'] );
 	}
 }


### PR DESCRIPTION
This PR makes two fundamental changes to the Site Health page:

1. It removes warnings/tests that are not useful on Pantheon's environment. Specifically, it removes tests for a writeable `/wp-content/update` folder, background updates (WP automatic updates) and "available disk space" checks (which are also affected by a read-only file system.
2. It adds a new test for object cache. If Redis is active and an object cache plugin (we recommend) is active, it will inform the user (OCP is preferred, WP Redis recommends OCP), if Redis is not active on the site it will warn and if Redis is active but neither of those plugins are active it will also warn.

**Redis is not active for the site**
<img width="903" alt="Screenshot 2024-04-22 at 4 02 21 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/59480cb3-b652-449b-a7e0-4e517eb3b4c6">

**Redis is active but WP-Redis or Object Cache Pro are not active**
<img width="921" alt="Screenshot 2024-04-22 at 3 59 01 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/32301104-e8fc-4e63-8baf-ab5eb8cb4cb1">

**Redis is active and WP-Redis is active**
<img width="954" alt="Screenshot 2024-04-22 at 3 59 39 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/a7fe1915-8116-467c-b2d5-9a8d734cdac5">

**Redis is active and Object Cache Pro is active
<img width="866" alt="Screenshot 2024-04-22 at 4 04 32 PM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/fb534af0-91ce-4087-ab23-b1ad07bbbcaa">
