### PR TITLE
[CMSP-1056] TTL to max-age

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ add_filter( 'pantheon_wp_login_text', function() {
 } );
 ```
 
-#### `pantheon_cache_default_ttl`
+#### `pantheon_cache_default_max_age`
 Filter the default cache max-age for the Pantheon Edge Cache.
 
 **Default Value:** `WEEK_IN_SECONDS` (604800)
 
 **Example:**
 ```php
-add_filter( 'pantheon_cache_default_ttl', function() {
+add_filter( 'pantheon_cache_default_max_age', function() {
     return 2 * WEEK_IN_SECONDS;
 } );
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ add_filter( 'pantheon_wp_login_text', function() {
 ```
 
 #### `pantheon_cache_default_ttl`
-Filter the default cache age for the Pantheon Edge Cache.
+Filter the default cache max-age for the Pantheon Edge Cache.
 
 **Default Value:** `WEEK_IN_SECONDS` (604800)
 

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -88,14 +88,14 @@ class Pantheon_Cache {
 	 */
 	protected function setup() {
 		/**
-		 * Modify the default TTL for the Pantheon cache. Defaults to 1 week.
+		 * Modify the default max-age for the Pantheon cache. Defaults to 1 week (604800 seconds).
 		 *
 		 * Usage:
 		 *  add_filter( 'pantheon_cache_default_ttl', function() {
 		 *      return DAY_IN_SECONDS;
 		 *  } );
 		 *
-		 * @param int $default_ttl The default TTL in seconds.
+		 * @param int $default_ttl The default max-age in seconds.
 		 */
 		$default_ttl = apply_filters( 'pantheon_cache_default_ttl', WEEK_IN_SECONDS );
 
@@ -221,19 +221,19 @@ class Pantheon_Cache {
 	}
 
 	/**
-	 * Add the HTML for the default TTL field.
+	 * Add the HTML for the default max-age field.
 	 *
 	 * @return void
 	 */
 	public function default_ttl_field() {
 		$disabled = ( has_filter( 'pantheon_cache_default_ttl' ) ) ? ' disabled' : '';
-		echo '<h3>' . esc_html__( 'Default Time to Live (TTL)', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher TTL typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<h3>' . esc_html__( 'Default Max Age', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher max-age typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" ' . $disabled . ' /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// Display a message if the setting is disabled.
 		if ( $disabled ) {
-			echo '<p>' . esc_html__( 'This setting is disabled because the default TTL has been filtered to the current value.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<p>' . esc_html__( 'This setting is disabled because the default max-age has been filtered to the current value.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -91,13 +91,13 @@ class Pantheon_Cache {
 		 * Modify the default max-age for the Pantheon cache. Defaults to 1 week (604800 seconds).
 		 *
 		 * Usage:
-		 *  add_filter( 'pantheon_cache_default_ttl', function() {
+		 *  add_filter( 'pantheon_cache_default_max_age', function() {
 		 *      return DAY_IN_SECONDS;
 		 *  } );
 		 *
 		 * @param int $default_ttl The default max-age in seconds.
 		 */
-		$default_ttl = apply_filters( 'pantheon_cache_default_ttl', WEEK_IN_SECONDS );
+		$default_ttl = apply_filters( 'pantheon_cache_default_max_age', WEEK_IN_SECONDS );
 
 		$this->options = get_option( self::SLUG, [] );
 		$this->default_options = [
@@ -226,7 +226,7 @@ class Pantheon_Cache {
 	 * @return void
 	 */
 	public function default_ttl_field() {
-		$disabled = ( has_filter( 'pantheon_cache_default_ttl' ) ) ? ' disabled' : '';
+		$disabled = ( has_filter( 'pantheon_cache_default_max_age' ) ) ? ' disabled' : '';
 		echo '<h3>' . esc_html__( 'Default Max Age', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher max-age typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" ' . $disabled . ' /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -194,21 +194,21 @@ class Test_Page_Cache extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the filtered value and display if the pantheon_cache_default_ttl filter is used.
+	 * Test the filtered value and display if the pantheon_cache_default_max_age filter is used.
 	 */
-	public function test_pantheon_cache_default_ttl_filter() {
+	public function test_pantheon_cache_default_max_age_filter() {
 		// Add a filter to change the default max-age to 120 seconds.
-		add_filter( 'pantheon_cache_default_ttl', function () {
+		add_filter( 'pantheon_cache_default_max_age', function () {
 			return 120;
 		} );
 
 		// Get the filtered default max-age.
-		$filtered_default_ttl = apply_filters( 'pantheon_cache_default_ttl', get_option( 'default_ttl' ) );
+		$filtered_default_ttl = apply_filters( 'pantheon_cache_default_max_age', get_option( 'default_ttl' ) );
 
 		// The filtered default max-age should be 120 seconds.
 		$this->assertEquals( 120, $filtered_default_ttl );
 
 		// Remove the filter.
-		remove_all_filters( 'pantheon_cache_default_ttl' );
+		remove_all_filters( 'pantheon_cache_default_max_age' );
 	}
 }

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -95,7 +95,7 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		];
 
 		$expected_output = [
-			'default_ttl' => 60, // Default TTL is set to 60 on live environments.
+			'default_ttl' => 60, // Default max-age is set to 60 on live environments.
 			'maintenance_mode' => 'disabled',
 		];
 		$output = $this->pantheon_cache->sanitize_options( $input );
@@ -197,15 +197,15 @@ class Test_Page_Cache extends WP_UnitTestCase {
 	 * Test the filtered value and display if the pantheon_cache_default_ttl filter is used.
 	 */
 	public function test_pantheon_cache_default_ttl_filter() {
-		// Add a filter to change the default TTL to 120 seconds.
+		// Add a filter to change the default max-age to 120 seconds.
 		add_filter( 'pantheon_cache_default_ttl', function () {
 			return 120;
 		} );
 
-		// Get the filtered default TTL.
+		// Get the filtered default max-age.
 		$filtered_default_ttl = apply_filters( 'pantheon_cache_default_ttl', get_option( 'default_ttl' ) );
 
-		// The filtered default TTL should be 120 seconds.
+		// The filtered default max-age should be 120 seconds.
 		$this->assertEquals( 120, $filtered_default_ttl );
 
 		// Remove the filter.


### PR DESCRIPTION
Replaces all references to "TTL" with "max-age" including in the new filter name.

See https://github.com/pantheon-systems/documentation/pull/8953#discussion_r1578171763