### PR TITLE
[BUGS-7678] update multisite install instructions to use `PANTHEON_HOSTNAME` constant

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -460,8 +460,8 @@ function network_step2( $errors = false ) {
 	<?php ob_start(); ?>
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
-define( 'DOMAIN_CURRENT_SITE', PANTHEON_HOSTNAME );
-define( 'PATH_CURRENT_SITE', '<?php echo $base; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>' );
+// Use PANTHEON_HOSTNAME if in a Pantheon environment, otherwise use HTTP_HOST.
+define( 'DOMAIN_CURRENT_SITE', defined( 'PANTHEON_HOSTNAME' ) ? PANTHEON_HOSTNAME : $_SERVER['HTTP_HOST'] );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 	<?php

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -459,12 +459,14 @@ function network_step2( $errors = false ) {
 		</label></p>
 		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="31" aria-describedby="network-wpconfig-rules-description">
 	<?php ob_start(); ?>
+$hostname = '<?php echo $hostname; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>'; // The domain of the network. Use as a fallback if $_SERVER['HTTP_HOST'] is not available.
 if ( !empty( $_ENV['PANTHEON_ENVIRONMENT'] )) {
 	$site_name = $_ENV['PANTHEON_SITE_NAME'];
 	// Override $hostname value as needed.
 	switch ( $_ENV['PANTHEON_ENVIRONMENT'] ) {
 		case 'live':
-			$hostname = $_SERVER['HTTP_HOST'];
+			// Fall back to the default $hostname if $_SERVER['HTTP_HOST'] is not available.
+			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $hostname;
 			break;
 		case 'test':
 			$hostname = 'test-' . $site_name . '.pantheonsite.io';

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -481,10 +481,8 @@ if ( !empty( $_ENV['PANTHEON_ENVIRONMENT'] )) {
 			$hostname = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $site_name . '.pantheonsite.io';
 			break;
 	}
-} else {
-	// Override with a default hostname.
-	$hostname = '<?php echo $hostname; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>';
 }
+
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
 define( 'DOMAIN_CURRENT_SITE', $hostname );

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -469,10 +469,10 @@ if ( !empty( $_ENV['PANTHEON_ENVIRONMENT'] )) {
 			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $hostname;
 			break;
 		case 'test':
-			$hostname = 'test-' . $site_name . '.pantheonsite.io';
+			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : 'test-' . $site_name . '.pantheonsite.io';
 			break;
 		case 'dev':
-			$hostname = 'dev-' . $site_name . '.pantheonsite.io';
+			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : 'dev-' . $site_name . '.pantheonsite.io';
 			break;
 		case 'lando':
 			$hostname = $site_name . '.lndo.site';

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -492,9 +492,14 @@ define( 'PATH_CURRENT_SITE', '<?php echo $base; // phpcs:ignore WordPress.Securi
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 	<?php
-	$config_file_contents = ob_get_contents();
-	ob_end_clean();
-	$config_file_contents = apply_filters( 'pantheon.multisite.config_contents', $config_file_contents );
+	/**
+	 * Filters the contents of the network configuration rules for WordPress configuration files.
+	 *
+	 * This allows this screen to be modified for different environments or configurations (e.g. Composer-based WordPress multisite).
+	 *
+	 * @param string $config_file_contents The contents of the network configuration rules.
+	 */
+	$config_file_contents = apply_filters( 'pantheon.multisite.config_contents', ob_get_clean() );
 	echo $config_file_contents; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	?>
 </textarea>

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -459,33 +459,9 @@ function network_step2( $errors = false ) {
 		</label></p>
 		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="31" aria-describedby="network-wpconfig-rules-description">
 	<?php ob_start(); ?>
-$hostname = '<?php echo $hostname; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>'; // The domain of the network. Use as a fallback if $_SERVER['HTTP_HOST'] is not available.
-if ( !empty( $_ENV['PANTHEON_ENVIRONMENT'] )) {
-	$site_name = $_ENV['PANTHEON_SITE_NAME'];
-	// Override $hostname value as needed.
-	switch ( $_ENV['PANTHEON_ENVIRONMENT'] ) {
-		case 'live':
-			// Fall back to the default $hostname if $_SERVER['HTTP_HOST'] is not available.
-			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $hostname;
-			break;
-		case 'test':
-			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : 'test-' . $site_name . '.pantheonsite.io';
-			break;
-		case 'dev':
-			$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : 'dev-' . $site_name . '.pantheonsite.io';
-			break;
-		case 'lando':
-			$hostname = $site_name . '.lndo.site';
-			break;
-		default:
-			$hostname = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $site_name . '.pantheonsite.io';
-			break;
-	}
-}
-
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
-define( 'DOMAIN_CURRENT_SITE', $hostname );
+define( 'DOMAIN_CURRENT_SITE', PANTHEON_HOSTNAME );
 define( 'PATH_CURRENT_SITE', '<?php echo $base; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>' );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -360,7 +360,6 @@ function network_step1( $errors = false ) {
 function network_step2( $errors = false ) {
 	global $wpdb, $is_nginx;
 
-	$hostname          = get_clean_basedomain();
 	$slashed_home      = trailingslashit( get_option( 'home' ) );
 	$base              = parse_url( $slashed_home, PHP_URL_PATH );
 	$document_root_fix = str_replace( '\\', '/', realpath( $_SERVER['DOCUMENT_ROOT'] ) );


### PR DESCRIPTION
This PR updates the network setup instructions to use the `PANTHEON_HOSTNAME` constant added in https://github.com/pantheon-systems/WordPress/pull/381 and https://github.com/pantheon-systems/wordpress-composer-managed/pull/119.