### PR TITLE
[CMSP-995 CMSP-992] make the default cache input box bigger

### DIFF
--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -229,7 +229,7 @@ class Pantheon_Cache {
 		$disabled = ( has_filter( 'pantheon_cache_default_max_age' ) ) ? ' disabled' : '';
 		echo '<h3>' . esc_html__( 'Default Max Age', 'pantheon-cache' ) . '</h3>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<p>' . esc_html__( 'Maximum time a cached page will be served. A higher max-age typically improves site performance.', 'pantheon-cache' ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="5" ' . $disabled . ' /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<input type="text" name="' . self::SLUG . '[default_ttl]" value="' . $this->options['default_ttl'] . '" size="7" ' . $disabled . ' /> ' . esc_html__( 'seconds', 'pantheon-cache' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// Display a message if the setting is disabled.
 		if ( $disabled ) {


### PR DESCRIPTION
This PR increases the size of the Default Max Age input box (which currently cuts off the last character when greater than 5 characters.


<img width="632" alt="Screenshot 2024-05-13 at 10 25 13 AM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/b90a9187-f6d4-4f14-bd1e-b94b891515d4">
