### PR TITLE
[BUGS-8085] Use filtered value when sending cache control headers

### DIFF
--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -363,7 +363,8 @@ class Pantheon_Cache {
 	 */
 	private function get_cache_control_header_value() {
 		if ( ! is_admin() && ! is_user_logged_in() ) {
-			$ttl = absint( $this->options['default_ttl'] );
+			// Use the filtered default max-age if applicable.
+			$ttl = apply_filters( 'pantheon_cache_default_max_age' , absint( $this->options['default_ttl'] ) );
 			if ( $ttl < 60 && isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'live' === $_ENV['PANTHEON_ENVIRONMENT'] ) {
 				$ttl = 60;
 			}

--- a/inc/pantheon-page-cache.php
+++ b/inc/pantheon-page-cache.php
@@ -364,7 +364,7 @@ class Pantheon_Cache {
 	private function get_cache_control_header_value() {
 		if ( ! is_admin() && ! is_user_logged_in() ) {
 			// Use the filtered default max-age if applicable.
-			$ttl = apply_filters( 'pantheon_cache_default_max_age' , absint( $this->options['default_ttl'] ) );
+			$ttl = apply_filters( 'pantheon_cache_default_max_age', absint( $this->options['default_ttl'] ) );
 			if ( $ttl < 60 && isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'live' === $_ENV['PANTHEON_ENVIRONMENT'] ) {
 				$ttl = 60;
 			}

--- a/tests/phpunit/test-page-cache.php
+++ b/tests/phpunit/test-page-cache.php
@@ -239,7 +239,11 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		$max_age = $this->get_max_age_from_rest_dispatch();
 
 		// Assert the default max-age.
-		$this->assertEquals( WEEK_IN_SECONDS, $max_age );
+		$this->assertEquals( 
+			WEEK_IN_SECONDS, 
+			$max_age, 
+			sprintf( 'Expected max-age to be the default value (%1$d) but got %2$d', WEEK_IN_SECONDS, $max_age ) 
+		);
 
 		// Filter the default max-age to 120 seconds.
 		add_filter( 'pantheon_cache_default_max_age', function () {
@@ -250,7 +254,10 @@ class Test_Page_Cache extends WP_UnitTestCase {
 		$max_age = $this->get_max_age_from_rest_dispatch();
 
 		// Assert the filtered max-age.
-		$this->assertNotEquals( WEEK_IN_SECONDS, $max_age );
-		$this->assertEquals( 120, $max_age );
+		$this->assertEquals(
+			120, 
+			$max_age,
+			sprintf( 'Expected max-age to be the filtered value (%1$d) but got %2$d', 120, $max_age )
+		);
 	}
 }


### PR DESCRIPTION
_Reported in community Slack by @brianperondi_

Filtered cache max-age values update in the admin and everywhere _except_ in the cache control header that is sent. 

This PR adds the filter to the value saved in `get_cache_control_header_value` which determines the value sent to the cache-control header.