### PR TITLE
[CMSP-150] Update network setup

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -457,7 +457,7 @@ function network_step2( $errors = false ) {
 			?>
 		</label></p>
 		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="31" aria-describedby="network-wpconfig-rules-description">
-	<?php ob_start(); ?>
+<?php ob_start(); ?>
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
 // Use PANTHEON_HOSTNAME if in a Pantheon environment, otherwise use HTTP_HOST.

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -456,7 +456,7 @@ function network_step2( $errors = false ) {
 			);
 			?>
 		</label></p>
-		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="31" aria-describedby="network-wpconfig-rules-description">
+		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="8" aria-describedby="network-wpconfig-rules-description">
 <?php ob_start(); ?>
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -438,7 +438,7 @@ function network_step2( $errors = false ) {
 		<?php
 		printf(
 			/* translators: 1: wp-config.php, 2: Location of wp-config file, 3: Translated version of "That's all, stop editing! Happy publishing." */
-			esc_html__( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ),
+			wp_kses_post( __( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ) ),
 			'<code>' . $config_filename . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'<code>' . $location_of_wp_config . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			// translators: This string should only be translated if wp-config-sample.php is localized.

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -457,7 +457,7 @@ function network_step2( $errors = false ) {
 			?>
 		</label></p>
 		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="8" aria-describedby="network-wpconfig-rules-description">
-<?php ob_start(); ?>
+<?php ob_start(); // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
 // Use PANTHEON_HOSTNAME if in a Pantheon environment, otherwise use HTTP_HOST.

--- a/pantheon.php
+++ b/pantheon.php
@@ -46,9 +46,8 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'WP_ALLOW_MULTISITE', true );
 	}
 	if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
-		if ( defined( 'MULTISITE' ) && MULTISITE ) {
-			require_once 'inc/pantheon-network-setup.php';
-		} else {
+		require_once 'inc/pantheon-network-setup.php';
+		if ( ! defined( 'MULTISITE' ) && MULTISITE ) {
 			require_once 'inc/pantheon-multisite-finalize.php';
 		}
 	}

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.4.3
+ * Version: 1.4.4
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.3' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.4' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';


### PR DESCRIPTION
This pull request fixes the network setup process by requiring the network setup file anytime allow multisite is true. Previously this was only included if MULTISITE was also true, but this prevents our network setup page (with the filters we've added) from displaying on the Network Setup page.

It also removes the tab before ob_start to fix the indentation in the textarea. 

Additionally, it reduces the number of lines in the textarea and uses `wp_kses_post` instead of `esc_html` to prevent escaping legitimate HTML.

<img width="1212" alt="Screenshot 2024-06-04 at 11 53 27 AM" src="https://github.com/pantheon-systems/pantheon-mu-plugin/assets/991511/7507eab1-70b7-4bb0-ba64-0cf1b278998d">
