### PR TITLE
[SITE-372] allow subdirectory networks warning to be filtered

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -104,7 +104,7 @@ function get_clean_basedomain() {
  *
  * Applies the 'pantheon.subdirectory_networks_message' filter.
  *
- * @since 1.4.4
+ * @since 1.4.5
  * @return string Warning message or empty string.
  */
 function pantheon_get_subdirectory_networks_message() {

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -100,6 +100,22 @@ function get_clean_basedomain() {
 }
 
 /**
+ * Returns the warning message about subdirectory multisites not liking custom wp-content directories.
+ *
+ * Applies the 'pantheon.subdirectory_networks_message' filter.
+ *
+ * @since 1.4.4
+ * @return string Warning message or empty string.
+ */
+function pantheon_get_subdirectory_networks_message() {
+	if ( apply_filters( 'pantheon.enable_subdirectory_networks_message', true ) ) {
+		return '<p><strong>' . __( 'Warning:' ) . ' ' . __( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</strong></p>';
+	}
+
+	return '';
+}
+
+/**
  * Prints step 1 for Network installation process.
  *
  * @todo Realistically, step 1 should be a welcome screen explaining what a Network is and such.
@@ -231,7 +247,7 @@ function network_step1( $errors = false ) {
 	endif;
 
 	if ( WP_CONTENT_DIR !== ABSPATH . 'wp-content' && ( allow_subdirectory_install() || ! allow_subdomain_install() ) ) {
-		echo '<div class="error inline"><p><strong>' . esc_html__( 'Warning:' ) . '</strong> ' . esc_html__( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</p></div>';
+		echo esc_html( pantheon_get_subdirectory_networks_message() );
 	}
 
 	$is_www = ( 0 === strpos( $hostname, 'www.' ) );
@@ -595,7 +611,8 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 			);
 		echo '</p>';
 		if ( ! $subdomain_install && WP_CONTENT_DIR !== ABSPATH . 'wp-content' ) {
-			echo '<p><strong>' . esc_html__( 'Warning:' ) . ' ' . esc_html__( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</strong></p>';
+			// Display the subdirectory networks message unless filtered.
+			echo esc_html( pantheon_get_subdirectory_networks_message() );
 		}
 		?>
 			<p class="configuration-rules-label"><label for="network-webconfig-rules">
@@ -657,7 +674,8 @@ EOF;
 		);
 		echo '</p>';
 		if ( ! $subdomain_install && WP_CONTENT_DIR !== ABSPATH . 'wp-content' ) {
-			echo '<p><strong>' . esc_html__( 'Warning:' ) . ' ' . esc_html__( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</strong></p>';
+			// Display the subdirectory networks message unless filtered.
+			echo esc_html( pantheon_get_subdirectory_networks_message() );
 		}
 		?>
 			<p class="configuration-rules-label"><label for="network-htaccess-rules">

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -109,7 +109,7 @@ function get_clean_basedomain() {
  */
 function pantheon_get_subdirectory_networks_message() {
 	if ( apply_filters( 'pantheon.enable_subdirectory_networks_message', true ) ) {
-		return '<p><strong>' . __( 'Warning:' ) . ' ' . __( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</strong></p>';
+		return '<div class="error inline"><p><strong>' . __( 'Warning:' ) . '</strong> ' . __( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</p></div>';
 	}
 
 	return '';

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.4' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.5' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';

--- a/tests/phpunit/test-network.php
+++ b/tests/phpunit/test-network.php
@@ -77,8 +77,11 @@ class Test_Network extends WP_UnitTestCase {
 	public function test_disable_subdirectory_custom_wp_content_warning() {
 		// Test the default condition.
 		$this->assertNotEmpty( pantheon_get_subdirectory_networks_message() );
+	}
 
+	public function test_disable_subdirectory_custom_wp_content_warning_filtered() {
 		add_filter( 'pantheon.enable_subdirectory_networks_message', '__return_false' );
 		$this->assertEmpty( pantheon_get_subdirectory_networks_message() );
 	}
+
 }

--- a/tests/phpunit/test-network.php
+++ b/tests/phpunit/test-network.php
@@ -83,5 +83,4 @@ class Test_Network extends WP_UnitTestCase {
 		add_filter( 'pantheon.enable_subdirectory_networks_message', '__return_false' );
 		$this->assertEmpty( pantheon_get_subdirectory_networks_message() );
 	}
-
 }

--- a/tests/phpunit/test-network.php
+++ b/tests/phpunit/test-network.php
@@ -73,4 +73,12 @@ class Test_Network extends WP_UnitTestCase {
 	public function test_pantheon_remove_network_setup() {
 		$this->assertNull( Pantheon\NetworkSetup\pantheon_remove_network_setup() );
 	}
+
+	public function test_disable_subdirectory_custom_wp_content_warning() {
+		// Test the default condition.
+		$this->assertNotEmpty( pantheon_get_subdirectory_networks_message() );
+
+		add_filter( 'pantheon.enable_subdirectory_networks_message', '__return_false' );
+		$this->assertEmpty( pantheon_get_subdirectory_networks_message() );
+	}
 }


### PR DESCRIPTION
This PR adds a new function that just returns a warning that appears on the Network Setup page in subdirectory multisite installs when the wp-content directory is modified (e.g. as it is in Bedrock). It then implements a filter to disable the warning that WordPress (Composer Managed) can consume (see https://github.com/pantheon-systems/wordpress-composer-managed/pull/144).

A test has been added to validate the output of the new function both before and after the filter has been applied.