### PR TITLE
Add PhastPress as an incompatible plugin

### DIFF
--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -300,6 +300,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#adthrive-ads'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'all-in-one-wp-migration' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -311,6 +312,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#all-in-one-wp-migration'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'bookly' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -322,6 +324,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#bookly'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'coming-soon' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -399,6 +402,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#h5p'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'hm-require-login' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -410,6 +414,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#hm-require-login'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'hummingbird-performance' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -432,6 +437,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#hyperdb'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'iwp-client' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -443,6 +449,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#infinitewp'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'instashow' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -454,6 +461,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#instashow'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'wp-maintenance-mode' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -465,6 +473,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#maintenance-mode'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'worker' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -487,6 +496,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#monarch-social-sharing'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'new-relic' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -542,6 +552,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#query-monitor'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'site24x7' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -564,6 +575,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#smush-pro'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'better-wp-security' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -586,6 +598,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#unbounce-landing-pages'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'unyson' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -619,6 +632,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#weather-station'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'webp-express' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),
@@ -685,6 +699,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#wp-phpmyadmin'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'wp-reset' => [
 			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
@@ -696,6 +711,7 @@ function get_compatibility_review_fixes() {
 					'https://docs.pantheon.io/plugins-known-issues#wp-reset'
 				)
 			),
+			'plugin_compatibility' => 'incompatible',
 		],
 		'wp-ban' => [
 			'plugin_status' => esc_html__( 'Partial Compatibility', 'pantheon' ),

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -824,12 +824,8 @@ function test_compatibility() {
 		);
 
 		if ( ! empty( $review_fixes ) ) {
-			ob_start();
-			output_compatibility_status_table( $manual_fixes, true );
-			$manual_table = ob_get_clean();
-			ob_start();
-			output_compatibility_status_table( $review_fixes, true, true );
-			$review_table = ob_get_clean();
+			$manual_table = output_compatibility_status_table( $manual_fixes, false );
+			$review_table = output_compatibility_status_table( $review_fixes, false, true );
 			$description = sprintf(
 				'<p>%1$s</p>%2$s<p>%3$s</p>%4$s',
 				__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -732,6 +732,18 @@ function get_compatibility_review_fixes() {
 				)
 			),
 		],
+		'phastpress' => [
+			'plugin_status' => esc_html__( 'Incompatible', 'pantheon' ),
+			'plugin_slug' => 'phastpress/phastpress.php',
+			'plugin_message' => wp_kses_post(
+				sprintf(
+					/* translators: %s: the link to relevant documentation. */
+					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
+					'https://docs.pantheon.io/plugins-known-issues#phastpress'
+				)
+			),
+			'plugin_compatibility' => 'incompatible',
+		]
 	];
 
 	return add_plugin_names_to_known_issues(

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -151,8 +151,8 @@ function output_compatibility_status_table( $plugins, $output = true, $incompati
 		<?php
 
 		// Filter out incompatible plugins. This allows us to re-use the status table for different types of compatibility issues.
-		if ( $incompatible && ( ! isset( $plugin['plugin_compatibility'] ) || $plugin['plugin_compatibility'] !== 'incompatible' ) ) {
-			$plugins = array_filter( $plugins, function( $plugins ) {
+		if ( $incompatible && ( ! isset( $plugins['plugin_compatibility'] ) || $plugins['plugin_compatibility'] !== 'incompatible' ) ) {
+			$plugins = array_filter( $plugins, function ( $plugins ) {
 				return $plugins['plugin_compatibility'] === 'incompatible';
 			} );
 		}
@@ -768,7 +768,7 @@ function get_compatibility_review_fixes() {
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
-		]
+		],
 	];
 
 	return add_plugin_names_to_known_issues(
@@ -845,7 +845,7 @@ function test_compatibility() {
 		$description = sprintf(
 			'<p>%s</p>%s',
 			__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),
-				output_compatibility_status_table( $manual_fixes, false )
+			output_compatibility_status_table( $manual_fixes, false )
 		);
 
 		if ( ! empty( $review_fixes ) ) {

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -842,14 +842,14 @@ function test_compatibility() {
 	}
 
 	if ( ! empty( $manual_fixes ) ) {
+		$manual_table = output_compatibility_status_table( $manual_fixes, false );
 		$description = sprintf(
 			'<p>%s</p>%s',
 			__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),
-			output_compatibility_status_table( $manual_fixes, false )
+			$manual_table
 		);
 
 		if ( ! empty( $review_fixes ) ) {
-			$manual_table = output_compatibility_status_table( $manual_fixes, false );
 			$review_table = output_compatibility_status_table( $review_fixes, false, true );
 			$description = sprintf(
 				'<p>%1$s</p>%2$s<p>%3$s</p>%4$s',

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -135,8 +135,9 @@ function output_compatibility_content( $tab ) {
  *
  * @param array $plugins
  * @param bool $output
+ * @param bool $incompatible True if only incompatible plugin issues should be displayed.
  */
-function output_compatibility_status_table( $plugins, $output = true ) {
+function output_compatibility_status_table( $plugins, $output = true, $incompatible = false ) {
 	ob_start();
 	?>
 	<table class='widefat striped health-check-table' role='presentation'>
@@ -148,6 +149,14 @@ function output_compatibility_status_table( $plugins, $output = true ) {
 		</thead>
 		<tbody>
 		<?php
+
+		// Filter out incompatible plugins. This allows us to re-use the status table for different types of compatibility issues.
+		if ( $incompatible && ( ! isset( $plugin['plugin_compatibility'] ) || $plugin['plugin_compatibility'] !== 'incompatible' ) ) {
+			$plugins = array_filter( $plugins, function( $plugins ) {
+				return $plugins['plugin_compatibility'] === 'incompatible';
+			} );
+		}
+
 		foreach ( $plugins as $field ) {
 			/* translators: %s: A plugin's compatibility status. */
 			$status = sprintf( __( '%s', 'pantheon' ), ucfirst( $field['plugin_status'] ) );

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -817,6 +817,28 @@ function test_compatibility() {
 	}
 
 	if ( ! empty( $manual_fixes ) ) {
+		$description = sprintf(
+			'<p>%s</p>%s',
+			__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),
+				output_compatibility_status_table( $manual_fixes, false )
+		);
+
+		if ( ! empty( $review_fixes ) ) {
+			ob_start();
+			output_compatibility_status_table( $manual_fixes, true );
+			$manual_table = ob_get_clean();
+			ob_start();
+			output_compatibility_status_table( $review_fixes, true, true );
+			$review_table = ob_get_clean();
+			$description = sprintf(
+				'<p>%1$s</p>%2$s<p>%3$s</p>%4$s',
+				__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),
+				$manual_table,
+				__( 'There are known incompatibility issues with the following plugins.', 'pantheon' ),
+				$review_table
+			);
+		}
+
 		return [
 			'label' => __( 'One or more active plugins require a manual compatibility fix', 'pantheon' ),
 			'status' => 'critical',
@@ -824,11 +846,7 @@ function test_compatibility() {
 				'label' => __( 'Pantheon', 'pantheon' ),
 				'color' => 'red',
 			],
-			'description' => sprintf(
-				'<p>%s</p>%s',
-				__( 'There are known compatibility issues with your active plugins that require manual fixes.', 'pantheon' ),
-				output_compatibility_status_table( $manual_fixes, false )
-			),
+			'description' => $description,
 			'test' => 'compatibility',
 		];
 	}

--- a/tests/phpunit/test-compatibility-layer.php
+++ b/tests/phpunit/test-compatibility-layer.php
@@ -87,4 +87,25 @@ class Test_Compatibility_Layer extends WP_UnitTestCase {
 		$this->assertIsArray( $applied_fixes );
 		$this->assertArrayHasKey( 'wp-force-login/wp-force-login.php', $applied_fixes );
 	}
+
+	public function test_output_compatibility_status_table() {
+		$plugins = get_option( 'active_plugins' );
+		foreach ( [ 'tuxedo-big-file-uploads/tuxedo_big_file_uploads.php', 'phastpress/phastpress.php' ] as $plugin ) {
+			$plugins[] = $plugin;
+		}
+		update_option( 'active_plugins', $plugins );
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		$manual_fixes = Pantheon\Site_Health\get_compatibility_manual_fixes();
+		$review_fixes = Pantheon\Site_Health\get_compatibility_review_fixes();
+		
+		$manual_table = Pantheon\Site_Health\output_compatibility_status_table( $manual_fixes, false );
+
+		$this->assertStringContainsString( 'Big-file-uploads', $manual_table );
+		$this->assertStringContainsString( 'Manual Fix Required', $manual_table );
+
+		$review_table = Pantheon\Site_Health\output_compatibility_status_table( $review_fixes, false, true );
+		$this->assertStringContainsString( 'Phastpress', $review_table );
+		$this->assertStringContainsString( 'Incompatible', $review_table );
+	}
 }


### PR DESCRIPTION
This PR adds the PhastPress plugin to the list of incompatible plugins (see [docs page](https://docs.pantheon.io/plugins-known-issues#phastpress)).

In addition to adding it to the items requireing _review_ (which lists partially and incompatible plugins), it updates the  main site health page to add any plugins that are _incompatible_ on Pantheon to the _critical_ issue section rather than listing them as _recommended improvements_ only.

This is accomplished by adding a new boolean parameter to the `output_compatibility_status_table` function that allows a list of plugins to be passed (e.g. from `get_compatibility_manual_fixes` / `get_compatibility_review_fiexes`) and specifically filter by an `incompatible` value in a new `plugin_compatibility` parameter that can be added to plugins when doing tests for the Site Health page.

The update displays incompatible plugins alongside plugins that require manual fixes or other things listed as Critical issues.

Tests have been added for the `output_compatibility_status_table` function.

Fixes #53
<img width="837" alt="Screenshot 2024-08-27 at 2 50 45 PM" src="https://github.com/user-attachments/assets/33a91252-1527-4c6a-89a9-66269a1eb17f">

