### PR TITLE
Add PHPCBF to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,46 @@
 name: Lint
 on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
+    phpcbf:
+      name: PHPCBF & Commit
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            ref: ${{ github.event.pull_request.head.ref }}
+        - name: PHPCBF
+          run: |
+            composer install
+            if ! composer phpcbf; then
+              echo "cbf=true" >> $GITHUB_ENV
+            else
+              echo "cbf=false" >> $GITHUB_ENV
+            fi
+        - name: Commit changes to PR
+          if: env.cbf == 'true'
+          run: |
+            git config --global user.email "bot@getpantheon.com"
+            git config --global user.name "Pantheon Robot"
+            if ! git diff-index --quiet HEAD --; then
+              CHANGES_DETECTED=true
+              git add *.php
+              git commit -m "PHPCBF: Fix coding standards" --no-verify
+              git push origin ${{ github.event.pull_request.head.ref }} || CHANGES_DETECTED=false
+              echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_ENV
+            else
+              echo "changes_detected=false" >> $GITHUB_ENV
+            fi
+        - name: Add PR Comment
+          if: changes_detected == 'true'
+          env:
+            GH_TOKEN: ${{ github.token }}
+          run: |
+            CURRENT_COMMIT=$(git rev-parse --short HEAD)
+            gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly Pantheon Robot! :robot: I fixed PHPCS issues with \`phpcbf\` on $CURRENT_COMMIT. Please review the changes."
     lint:
         name: Lint
         runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: push
+on: [pull_request]
 jobs:
     lint:
         name: Lint


### PR DESCRIPTION
This pull request updates the lint workflow to run PHPCBF on pull requests and commit any changes back to the PR before running lint. It also switches the action to run on pull requests instead of on every push so we can pull details from the GH API to inform the PR comment. 