### PR TITLE
Add PATH_CURRENT_SITE to multisite setup instructions

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -478,6 +478,7 @@ define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
 // Use PANTHEON_HOSTNAME if in a Pantheon environment, otherwise use HTTP_HOST.
 define( 'DOMAIN_CURRENT_SITE', defined( 'PANTHEON_HOSTNAME' ) ? PANTHEON_HOSTNAME : $_SERVER['HTTP_HOST'] );
+define( 'PATH_CURRENT_SITE', '/' );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
 	<?php


### PR DESCRIPTION
This pull request adds the `PATH_CURRENT_SITE` constant to the multisite setup instructions. This constant is set to `'/'` and is used to define the current site's path.

Fixes #54