### PR TITLE
Allow the "happy publishing" line in the network config to be filtered

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -389,7 +389,7 @@ function network_step2( $errors = false ) {
 	if ( ! file_exists( ABSPATH . $config_filename ) && file_exists( dirname( ABSPATH ) . '/' . $config_filename ) ) {
 		$location_of_wp_config = dirname( $abspath_fix );
 	}
-	$location_of_wp_config = trailingslashit( $location_of_wp_config );
+	$location_of_wp_config = apply_filters( 'pantheon.multisite.location_of_wp_config', trailingslashit( $location_of_wp_config ) );
 
 	// Wildcard DNS message.
 	if ( is_wp_error( $errors ) ) {

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -383,8 +383,6 @@ function network_step2( $errors = false ) {
 	$home_path         = 0 === strpos( $abspath_fix, $document_root_fix ) ? $document_root_fix . $base : get_home_path();
 	$wp_siteurl_subdir = preg_replace( '#^' . preg_quote( $home_path, '#' ) . '#', '', $abspath_fix );
 	$rewrite_base      = ! empty( $wp_siteurl_subdir ) ? ltrim( trailingslashit( $wp_siteurl_subdir ), '/' ) : '';
-
-	$config_filename = 'wp-config.php';
 	$config_filename = apply_filters( 'pantheon.multisite.config_filename', 'wp-config.php' );
 
 	$location_of_wp_config = $abspath_fix;

--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -446,6 +446,8 @@ function network_step2( $errors = false ) {
 		</p></div>
 		<?php
 	}
+
+	$happy_publishing_msg = apply_filters( 'pantheon.multisite.end_of_file_message', '<code>/* ' . esc_html__( 'That&#8217;s all, stop editing! Happy publishing.' ) . ' */</code>' );
 	?>
 	<ol>
 		<li><p id="network-wpconfig-rules-description">
@@ -455,9 +457,7 @@ function network_step2( $errors = false ) {
 			wp_kses_post( __( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ) ),
 			'<code>' . $config_filename . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'<code>' . $location_of_wp_config . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			// translators: This string should only be translated if wp-config-sample.php is localized.
-			// You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php.
-			'<code>/* ' . esc_html__( 'That&#8217;s all, stop editing! Happy publishing.' ) . ' */</code>'
+			$happy_publishing_msg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 		?>
 		</p>

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -259,8 +259,8 @@ function get_compatibility_manual_fixes() {
 					__( 'WP Cerber conflicts with Pantheon\'s Global CDN caching. Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
 					'https://docs.pantheon.io/plugins-known-issues#wp-cerber'
 				)
-			)
-		]
+			),
+		],
 	];
 
 	return add_plugin_names_to_known_issues(


### PR DESCRIPTION


This pull request allows the happy publishing line to be filtered so that it can refer to any line at the end of the file.

Additionally, it removes a redundant variable definition for the WP config file name and makes the location of WP config file filterable.

fixes #55