### PR TITLE
SITE-2577: Disable HEIC support for now

### DIFF
--- a/inc/pantheon-media.php
+++ b/inc/pantheon-media.php
@@ -1,0 +1,11 @@
+<?php 
+
+/*
+ * HEIC support added in 6.7 but not yet supported by ImageMagick on Pantheon.
+ */
+add_filter( 'image_editor_output_format', function( $output_format ) {
+    if ( isset($output_format['image/heic'] ) ) {
+	    unset( $output_format['image/heic'] );
+    }
+    return $output_format;
+} );

--- a/inc/pantheon-media.php
+++ b/inc/pantheon-media.php
@@ -1,8 +1,11 @@
 <?php 
+/**
+ * Media handling adjustments while on Pantheon.
+ **/
 
-/*
+/**
  * HEIC support added in 6.7 but not yet supported by ImageMagick on Pantheon.
- */
+ **/
 add_filter( 'image_editor_output_format', function ( $output_format ) {
 	if ( isset( $output_format['image/heic'] ) ) {
 		unset( $output_format['image/heic'] );

--- a/inc/pantheon-media.php
+++ b/inc/pantheon-media.php
@@ -3,9 +3,9 @@
 /*
  * HEIC support added in 6.7 but not yet supported by ImageMagick on Pantheon.
  */
-add_filter( 'image_editor_output_format', function( $output_format ) {
-    if ( isset($output_format['image/heic'] ) ) {
-	    unset( $output_format['image/heic'] );
-    }
-    return $output_format;
+add_filter( 'image_editor_output_format', function ( $output_format ) {
+	if ( isset( $output_format['image/heic'] ) ) {
+		unset( $output_format['image/heic'] );
+	}
+	return $output_format;
 } );

--- a/pantheon.php
+++ b/pantheon.php
@@ -10,10 +10,11 @@
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.1' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.2' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';
+	require_once 'inc/pantheon-media.php';
 	require_once 'inc/pantheon-page-cache.php';
 	require_once 'inc/site-health.php';
 	if ( ! defined( 'DISABLE_PANTHEON_UPDATE_NOTICES' ) || ! DISABLE_PANTHEON_UPDATE_NOTICES ) {


### PR DESCRIPTION
Our build of ImageMagick does not yet support HEIC images.

-------
c/f https://make.wordpress.org/core/2024/08/15/automatic-conversion-of-heic-images-to-jpeg-in-wordpress-6-7/
https://getpantheon.atlassian.net/browse/SITE-2577