### PR TITLE
[BUGS-9130] Don't add network setup if network already setup

### DIFF
--- a/inc/pantheon-network-setup.php
+++ b/inc/pantheon-network-setup.php
@@ -25,6 +25,10 @@ function pantheon_remove_network_setup() {
  * Register the Pantheon network setup submenu page.
  */
 function pantheon_add_network_setup() {
+	if ( defined( 'MULTISITE' ) && MULTISITE ) {
+		return;
+	}
+
 	add_management_page(
 		__( 'Create a Network of WordPress  Sites', 'network-setup' ),
 		__( 'Network Setup', 'network-setup' ),


### PR DESCRIPTION
Skip adding our custom network setup page if multisite has already been configured (MULTISITE constant is true).