### PR TITLE
updates all references to `/plugins-known-issues` with `/wordpress-known-issues`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Allows you to filter plugins with known compatibility issues on Pantheon so they
 			sprintf(
 				/* translators: %s: the link to relevant documentation. */
 				__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-				'https://docs.pantheon.io/plugins-known-issues#big-file-uploads'
+				'https://docs.pantheon.io/wordpress-known-issues#big-file-uploads'
 			)
 		),
 	],
@@ -117,7 +117,7 @@ Allows you to filter plugins with known compatibility issues on Pantheon so they
 			sprintf(
 				/* translators: %s: the link to relevant documentation. */
 				__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-				'https://docs.pantheon.io/plugins-known-issues#jetpack'
+				'https://docs.pantheon.io/wordpress-known-issues#jetpack'
 			)
 		),
 	],
@@ -128,7 +128,7 @@ Allows you to filter plugins with known compatibility issues on Pantheon so they
 			sprintf(
 				/* translators: %s: the link to relevant documentation. */
 				__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-				'https://docs.pantheon.io/plugins-known-issues#wordfence'
+				'https://docs.pantheon.io/wordpress-known-issues#wordfence'
 			)
 		),
 	],

--- a/inc/compatibility/class-acceleratedmobilepages.php
+++ b/inc/compatibility/class-acceleratedmobilepages.php
@@ -2,7 +2,7 @@
 /**
  * Accelerated Mobile Pages compatibility fix.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#amp-for-wp--accelerated-mobile-pages
+ * @link https://docs.pantheon.io/wordpress-known-issues#amp-for-wp--accelerated-mobile-pages
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-auth0.php
+++ b/inc/compatibility/class-auth0.php
@@ -2,7 +2,7 @@
 /**
  * Auth0 Compatibility
  *
- * @link https://docs.pantheon.io/plugins-known-issues#auth0
+ * @link https://docs.pantheon.io/wordpress-known-issues#auth0
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-autoptimize.php
+++ b/inc/compatibility/class-autoptimize.php
@@ -2,7 +2,7 @@
 /**
  * Autoptimize Compatibility
  *
- * @link https://docs.pantheon.io/plugins-known-issues#autoptimize
+ * @link https://docs.pantheon.io/wordpress-known-issues#autoptimize
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-bettersearchreplace.php
+++ b/inc/compatibility/class-bettersearchreplace.php
@@ -2,7 +2,7 @@
 /**
  * Better Search Replace compatibility fix.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#better-search-and-replace
+ * @link https://docs.pantheon.io/wordpress-known-issues#better-search-and-replace
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-brokenlinkchecker.php
+++ b/inc/compatibility/class-brokenlinkchecker.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility class for Broken Link Checker plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#broken-link-checker
+ * @link https://docs.pantheon.io/wordpress-known-issues#broken-link-checker
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-contactformseven.php
+++ b/inc/compatibility/class-contactformseven.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility class for Contact Form 7 plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#contact-form-7
+ * @link https://docs.pantheon.io/wordpress-known-issues#contact-form-7
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-eventespresso.php
+++ b/inc/compatibility/class-eventespresso.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility fix for Event Espresso
  *
- * @link https://docs.pantheon.io/plugins-known-issues#event-espresso
+ * @link https://docs.pantheon.io/wordpress-known-issues#event-espresso
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-fastvelocityminify.php
+++ b/inc/compatibility/class-fastvelocityminify.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility fix for Fast Velocity Minify plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#fast-velocity-minify
+ * @link https://docs.pantheon.io/wordpress-known-issues#fast-velocity-minify
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-forcelogin.php
+++ b/inc/compatibility/class-forcelogin.php
@@ -2,7 +2,7 @@
 /**
  * Force Login compatibility fix.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#force-login
+ * @link https://docs.pantheon.io/wordpress-known-issues#force-login
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-officialfacebookpixel.php
+++ b/inc/compatibility/class-officialfacebookpixel.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility fix for Official Facebook Pixel plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#facebook-for-wordpress-official-facebook-pixel
+ * @link https://docs.pantheon.io/wordpress-known-issues#facebook-for-wordpress-official-facebook-pixel
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-polylang.php
+++ b/inc/compatibility/class-polylang.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility fix for Polylang plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#polylang
+ * @link https://docs.pantheon.io/wordpress-known-issues#polylang
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-redirection.php
+++ b/inc/compatibility/class-redirection.php
@@ -2,7 +2,7 @@
 /**
  * Redirection compatibility class
  *
- * @link https://docs.pantheon.io/plugins-known-issues#redirection
+ * @link https://docs.pantheon.io/wordpress-known-issues#redirection
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-sliderrevolution.php
+++ b/inc/compatibility/class-sliderrevolution.php
@@ -2,7 +2,7 @@
 /**
  * Slider Revolution Compatibility
  *
- * @link https://docs.pantheon.io/plugins-known-issues#slider-revolution
+ * @link https://docs.pantheon.io/wordpress-known-issues#slider-revolution
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-tweetoldpost.php
+++ b/inc/compatibility/class-tweetoldpost.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility class for Tweet Old Post plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#revive-old-post
+ * @link https://docs.pantheon.io/wordpress-known-issues#revive-old-post
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-woozone.php
+++ b/inc/compatibility/class-woozone.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility fix for WooZone.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#woozone
+ * @link https://docs.pantheon.io/wordpress-known-issues#woozone
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-wprocket.php
+++ b/inc/compatibility/class-wprocket.php
@@ -2,7 +2,7 @@
 /**
  * Compatibility class for WP Rocket plugin.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#wp-rocket
+ * @link https://docs.pantheon.io/wordpress-known-issues#wp-rocket
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/class-yithwoocommerce.php
+++ b/inc/compatibility/class-yithwoocommerce.php
@@ -2,7 +2,7 @@
 /**
  * YITH WooCommerce Compatibility
  *
- * @link https://docs.pantheon.io/plugins-known-issues#yith-woocommerce-extensions-with-mpdf-library
+ * @link https://docs.pantheon.io/wordpress-known-issues#yith-woocommerce-extensions-with-mpdf-library
  * @package Pantheon\Compatibility
  */
 

--- a/inc/compatibility/fixes/class-acceleratedmobilepagesfix.php
+++ b/inc/compatibility/fixes/class-acceleratedmobilepagesfix.php
@@ -2,7 +2,7 @@
 /**
  * Accelerated Mobile Pages Fix
  *
- * @link https://docs.pantheon.io/plugins-known-issues#amp-for-wp--accelerated-mobile-pages
+ * @link https://docs.pantheon.io/wordpress-known-issues#amp-for-wp--accelerated-mobile-pages
  * @package Pantheon\Compatibility\Fixes
  */
 

--- a/inc/compatibility/fixes/class-auth0fix.php
+++ b/inc/compatibility/fixes/class-auth0fix.php
@@ -2,7 +2,7 @@
 /**
  * Auth0 Fix
  *
- * @link https://docs.pantheon.io/plugins-known-issues#auth0
+ * @link https://docs.pantheon.io/wordpress-known-issues#auth0
  * @package Pantheon\Compatibility\Fixes
  */
 

--- a/inc/compatibility/fixes/class-autoptimizefix.php
+++ b/inc/compatibility/fixes/class-autoptimizefix.php
@@ -2,7 +2,7 @@
 /**
  * AutoptimizeFix
  *
- * @link https://docs.pantheon.io/plugins-known-issues#autoptimize
+ * @link https://docs.pantheon.io/wordpress-known-issues#autoptimize
  * @package Pantheon\Compatibility\Fixes
  */
 

--- a/inc/compatibility/fixes/class-sliderrevolutionfix.php
+++ b/inc/compatibility/fixes/class-sliderrevolutionfix.php
@@ -2,7 +2,7 @@
 /**
  * Slider Revolution Fix
  *
- * @link https://docs.pantheon.io/plugins-known-issues#slider-revolution
+ * @link https://docs.pantheon.io/wordpress-known-issues#slider-revolution
  * @package Pantheon
  */
 

--- a/inc/compatibility/fixes/class-wprocketfix.php
+++ b/inc/compatibility/fixes/class-wprocketfix.php
@@ -2,7 +2,7 @@
 /**
  * WP Rocket compatibility fix.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#wp-rocket
+ * @link https://docs.pantheon.io/wordpress-known-issues#wp-rocket
  * @package Pantheon\Compatibility\Fixes
  */
 

--- a/inc/compatibility/fixes/class-yithchangepdflocationfix.php
+++ b/inc/compatibility/fixes/class-yithchangepdflocationfix.php
@@ -2,7 +2,7 @@
 /**
  * Changes PDF cache location for YITH WooCommerce extensions.
  *
- * @link https://docs.pantheon.io/plugins-known-issues#yith-woocommerce-extensions-with-mpdf-library
+ * @link https://docs.pantheon.io/wordpress-known-issues#yith-woocommerce-extensions-with-mpdf-library
  * @package Pantheon\Compatibility\Fixes
  */
 

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -66,7 +66,7 @@ function output_compatibility_content( $tab ) {
 					/* translators: %s: URL to Known Issues page. */
 					__( 'This page lists active plugins that have known compatibility issues with Pantheon\'s infrastructure. For additional details, see the <a href="%s" target="_blank">Known Issues</a> page.', 'pantheon' )
 				),
-				esc_url( 'https://docs.pantheon.io/plugins-known-issues' )
+				esc_url( 'https://docs.pantheon.io/wordpress-known-issues' )
 			);
 			?>
 		</p>
@@ -213,7 +213,7 @@ function get_compatibility_manual_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#big-file-uploads'
+					'https://docs.pantheon.io/wordpress-known-issues#big-file-uploads'
 				)
 			),
 		],
@@ -224,7 +224,7 @@ function get_compatibility_manual_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#jetpack'
+					'https://docs.pantheon.io/wordpress-known-issues#jetpack'
 				)
 			),
 		],
@@ -235,7 +235,7 @@ function get_compatibility_manual_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wordfence'
+					'https://docs.pantheon.io/wordpress-known-issues#wordfence'
 				)
 			),
 		],
@@ -246,7 +246,7 @@ function get_compatibility_manual_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wpml-the-wordpress-multilingual-plugin'
+					'https://docs.pantheon.io/wordpress-known-issues#wpml-the-wordpress-multilingual-plugin'
 				)
 			),
 		],
@@ -257,7 +257,7 @@ function get_compatibility_manual_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'WP Cerber conflicts with Pantheon\'s Global CDN caching. Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-cerber'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-cerber'
 				)
 			),
 		],
@@ -313,7 +313,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#adthrive-ads'
+					'https://docs.pantheon.io/wordpress-known-issues#adthrive-ads'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -325,7 +325,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#all-in-one-wp-migration'
+					'https://docs.pantheon.io/wordpress-known-issues#all-in-one-wp-migration'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -337,7 +337,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#bookly'
+					'https://docs.pantheon.io/wordpress-known-issues#bookly'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -349,7 +349,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#coming-soon'
+					'https://docs.pantheon.io/wordpress-known-issues#coming-soon'
 				)
 			),
 		],
@@ -360,7 +360,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#disable-rest-api-and-require-jwt--oauth-authentication'
+					'https://docs.pantheon.io/wordpress-known-issues#disable-rest-api-and-require-jwt--oauth-authentication'
 				)
 			),
 		],
@@ -371,7 +371,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#divi-wordpress-theme--visual-page-builder'
+					'https://docs.pantheon.io/wordpress-known-issues#divi-wordpress-theme--visual-page-builder'
 				)
 			),
 		],
@@ -382,7 +382,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#elementor'
+					'https://docs.pantheon.io/wordpress-known-issues#elementor'
 				)
 			),
 		],
@@ -393,7 +393,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#facetwp'
+					'https://docs.pantheon.io/wordpress-known-issues#facetwp'
 				)
 			),
 		],
@@ -404,7 +404,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#gdpr-cookie-consent'
+					'https://docs.pantheon.io/wordpress-known-issues#gdpr-cookie-consent'
 				)
 			),
 		],
@@ -415,7 +415,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#h5p'
+					'https://docs.pantheon.io/wordpress-known-issues#h5p'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -427,7 +427,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#hm-require-login'
+					'https://docs.pantheon.io/wordpress-known-issues#hm-require-login'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -439,7 +439,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#hummingbird'
+					'https://docs.pantheon.io/wordpress-known-issues#hummingbird'
 				)
 			),
 		],
@@ -450,7 +450,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#hyperdb'
+					'https://docs.pantheon.io/wordpress-known-issues#hyperdb'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -462,7 +462,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#infinitewp'
+					'https://docs.pantheon.io/wordpress-known-issues#infinitewp'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -474,7 +474,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#instashow'
+					'https://docs.pantheon.io/wordpress-known-issues#instashow'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -486,7 +486,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#maintenance-mode'
+					'https://docs.pantheon.io/wordpress-known-issues#maintenance-mode'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -498,7 +498,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#managewp-worker'
+					'https://docs.pantheon.io/wordpress-known-issues#managewp-worker'
 				)
 			),
 		],
@@ -509,7 +509,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#monarch-social-sharing'
+					'https://docs.pantheon.io/wordpress-known-issues#monarch-social-sharing'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -521,7 +521,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#new-relic-reporting-for-wordpress'
+					'https://docs.pantheon.io/wordpress-known-issues#new-relic-reporting-for-wordpress'
 				)
 			),
 		],
@@ -532,7 +532,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#object-sync-for-salesforce'
+					'https://docs.pantheon.io/wordpress-known-issues#object-sync-for-salesforce'
 				)
 			),
 		],
@@ -543,7 +543,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#one-click-demo-import'
+					'https://docs.pantheon.io/wordpress-known-issues#one-click-demo-import'
 				)
 			),
 		],
@@ -554,7 +554,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#posts-2-posts'
+					'https://docs.pantheon.io/wordpress-known-issues#posts-2-posts'
 				)
 			),
 		],
@@ -565,7 +565,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#query-monitor'
+					'https://docs.pantheon.io/wordpress-known-issues#query-monitor'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -577,7 +577,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#site24x7'
+					'https://docs.pantheon.io/wordpress-known-issues#site24x7'
 				)
 			),
 		],
@@ -588,7 +588,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#smush-pro'
+					'https://docs.pantheon.io/wordpress-known-issues#smush-pro'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -600,7 +600,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#solid-security-previously-ithemes-security'
+					'https://docs.pantheon.io/wordpress-known-issues#solid-security-previously-ithemes-security'
 				)
 			),
 		],
@@ -611,7 +611,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#unbounce-landing-pages'
+					'https://docs.pantheon.io/wordpress-known-issues#unbounce-landing-pages'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -623,7 +623,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#unyson-theme-framework'
+					'https://docs.pantheon.io/wordpress-known-issues#unyson-theme-framework'
 				)
 			),
 		],
@@ -634,7 +634,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#updraft--updraft-plus-backup'
+					'https://docs.pantheon.io/wordpress-known-issues#updraft--updraft-plus-backup'
 				)
 			),
 		],
@@ -645,7 +645,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#weather-station'
+					'https://docs.pantheon.io/wordpress-known-issues#weather-station'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -657,7 +657,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#webp-express'
+					'https://docs.pantheon.io/wordpress-known-issues#webp-express'
 				)
 			),
 		],
@@ -668,7 +668,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#woocommerce'
+					'https://docs.pantheon.io/wordpress-known-issues#woocommerce'
 				)
 			),
 		],
@@ -679,7 +679,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wordpress-download-manager'
+					'https://docs.pantheon.io/wordpress-known-issues#wordpress-download-manager'
 				)
 			),
 		],
@@ -690,7 +690,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-all-import--export'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-all-import--export'
 				)
 			),
 		],
@@ -701,7 +701,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-migrate-db'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-migrate-db'
 				)
 			),
 		],
@@ -712,7 +712,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-phpmyadmin'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-phpmyadmin'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -724,7 +724,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-reset'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-reset'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',
@@ -736,7 +736,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wp-ban'
+					'https://docs.pantheon.io/wordpress-known-issues#wp-ban'
 				)
 			),
 		],
@@ -747,7 +747,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#wpfront-notification-bar'
+					'https://docs.pantheon.io/wordpress-known-issues#wpfront-notification-bar'
 				)
 			),
 		],
@@ -758,7 +758,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#yoast-seo'
+					'https://docs.pantheon.io/wordpress-known-issues#yoast-seo'
 				)
 			),
 		],
@@ -769,7 +769,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#yoast-indexables'
+					'https://docs.pantheon.io/wordpress-known-issues#yoast-indexables'
 				)
 			),
 		],
@@ -780,7 +780,7 @@ function get_compatibility_review_fixes() {
 				sprintf(
 					/* translators: %s: the link to relevant documentation. */
 					__( 'Read more about the issue <a href="%s" target="_blank">here</a>.', 'pantheon' ),
-					'https://docs.pantheon.io/plugins-known-issues#phastpress'
+					'https://docs.pantheon.io/wordpress-known-issues#phastpress'
 				)
 			),
 			'plugin_compatibility' => 'incompatible',


### PR DESCRIPTION
relates to https://github.com/pantheon-systems/documentation/pull/9433

- [x] hold for https://github.com/pantheon-systems/documentation/pull/9433 merge

fixes #79