### PR TITLE
Fix WPRocket deactivation hook

### DIFF
--- a/inc/compatibility/fixes/class-wprocketfix.php
+++ b/inc/compatibility/fixes/class-wprocketfix.php
@@ -25,4 +25,9 @@ class WPRocketFix {
 		DefineConstantFix::apply( 'WP_ROCKET_CACHE_ROOT_URL',
 		sprintf( '%s/wp-content/uploads/wp-rocket/cache/', $home_url ) );
 	}
+
+	/**
+	 * @return void
+	 */
+	public static function remove() {}
 }


### PR DESCRIPTION
This PR adds an empty remove method. We're not removing anything, so we don't need to do anything. Currently the WPRocket class inside the MU Plugin compatibility layer references the `remove()` method so if you deactivate the plugin and it tries to remove any fixes, the deactivation breaks.