### PR TITLE
Hook constants fixes to an earlier hook than `plugins_loaded`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
               echo "cbf=false" >> $GITHUB_ENV
             fi
         - name: Commit changes to PR
-          if: env.cbf == 'true'
+          if: ${{ env.cbf == 'true' }}
           run: |
             git config --global user.email "bot@getpantheon.com"
             git config --global user.name "Pantheon Robot"
@@ -35,7 +35,7 @@ jobs:
               echo "changes_detected=false" >> $GITHUB_ENV
             fi
         - name: Add PR Comment
-          if: changes_detected == 'true'
+          if: ${{ env.changes_detected == 'true' }}
           env:
             GH_TOKEN: ${{ github.token }}
           run: |

--- a/inc/compatibility/class-compatibilityfactory.php
+++ b/inc/compatibility/class-compatibilityfactory.php
@@ -136,7 +136,7 @@ class CompatibilityFactory {
 	}
 
 	/**
-	 * Instantiate classes.
+	 * Instantiate classes & register cron job.
 	 *
 	 * @access public
 	 *
@@ -148,6 +148,10 @@ class CompatibilityFactory {
 		}
 
 		$this->instantiate_compatibility_layers();
+
+		if ( ! wp_next_scheduled( 'pantheon_cron' ) ) {
+			wp_schedule_event( time(), 'daily', 'pantheon_cron' );
+		}
 	}
 
 	/**

--- a/inc/compatibility/class-compatibilityfactory.php
+++ b/inc/compatibility/class-compatibilityfactory.php
@@ -48,7 +48,7 @@ class CompatibilityFactory {
 		$this->require_files();
 		$this->setup_targets();
 
-		add_action( 'plugins_loaded', [ $this, 'init' ] );
+		add_action( 'muplugins_loaded', [ $this, 'init' ] );
 		add_action( 'pantheon_cron', [ $this, 'daily_pantheon_cron' ] );
 	}
 

--- a/inc/compatibility/class-compatibilityfactory.php
+++ b/inc/compatibility/class-compatibilityfactory.php
@@ -49,6 +49,7 @@ class CompatibilityFactory {
 		$this->setup_targets();
 
 		add_action( 'muplugins_loaded', [ $this, 'init' ] );
+		add_action( 'plugins_loaded', [ $this, 'init_cron' ] );
 		add_action( 'pantheon_cron', [ $this, 'daily_pantheon_cron' ] );
 	}
 
@@ -135,7 +136,7 @@ class CompatibilityFactory {
 	}
 
 	/**
-	 * Instantiate classes and register cron job.
+	 * Instantiate classes.
 	 *
 	 * @access public
 	 *
@@ -147,7 +148,16 @@ class CompatibilityFactory {
 		}
 
 		$this->instantiate_compatibility_layers();
+	}
 
+	/**
+	 * Register cron job.
+	 *
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function init_cron() {
 		if ( ! wp_next_scheduled( 'pantheon_cron' ) ) {
 			wp_schedule_event( time(), 'daily', 'pantheon_cron' );
 		}

--- a/inc/compatibility/class-compatibilityfactory.php
+++ b/inc/compatibility/class-compatibilityfactory.php
@@ -48,8 +48,8 @@ class CompatibilityFactory {
 		$this->require_files();
 		$this->setup_targets();
 
-		add_action( 'muplugins_loaded', [ $this, 'init' ] );
-		add_action( 'plugins_loaded', [ $this, 'init_cron' ] );
+		add_action( 'muplugins_loaded', [ $this, 'init_constant_fixes' ] );
+		add_action( 'plugins_loaded', [ $this, 'init' ] );
 		add_action( 'pantheon_cron', [ $this, 'daily_pantheon_cron' ] );
 	}
 
@@ -155,15 +155,27 @@ class CompatibilityFactory {
 	}
 
 	/**
-	 * Register cron job.
+	 * Instantiate fixes that update constants.
 	 *
 	 * @access public
 	 *
 	 * @return void
 	 */
-	public function init_cron() {
-		if ( ! wp_next_scheduled( 'pantheon_cron' ) ) {
-			wp_schedule_event( time(), 'daily', 'pantheon_cron' );
+	public function init_constant_fixes() {
+		// Instantiate only the classes that define constant fixes.
+		$constant_fixes = [
+			ContactFormSeven::class,
+			FastVelocityMinify::class,
+			Polylang::class,
+			WooZone::class,
+			Autoptimize::class,
+			WPRocket::class,
+		];
+
+		foreach ( $constant_fixes as $class ) {
+			if ( isset( static::$targets[ $class ] ) ) {
+				new $class( static::$targets[ $class ]['slug'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds a new method hooked to `muplugins_loaded` (which is the first action hook fired by WP and is before `plugins_loaded`) and hooks the `DefineConstantFix` fixes to that (rather than when all the other fixes are applied, e.g. `plugins_loaded`).

fixes #82 (hopefully)