### PR TITLE
Feedback wanted: Default to Gravatar-based avatars when FAIR is active

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Pantheon-specific settings overrides.
+ *
+ * @package pantheon
+ */
+
+namespace Pantheon\Settings;
+
+/**
+ * Bootstrap the settings.
+ */
+function bootstrap() {
+	add_action( 'admin_init', __NAMESPACE__ . '\\set_default_fair_avatar_to_gravatar' );
+}
+
+/**
+ * Set the default FAIR avatar to Gravatar if FAIR is active and not already set.
+ */
+function set_default_fair_avatar_to_gravatar() {
+	if ( ! function_exists( '\\FAIR\\bootstrap' ) ) {
+		// Bail early if we're not using FAIR.
+		return;
+	}
+
+	// Check for FAIR settings.
+	$fair_settings = get_option( 'fair_settings', [] );
+	if ( empty( $fair_settings ) ) {
+		return;
+	}
+
+	// Make sure that avatar_source is not set.
+	if ( isset( $fair_settings['avatar_source'] ) ) {
+		return;
+	}
+
+	// Set avatar_source to gravatar if unset.
+	$fair_settings['avatar_source'] = 'gravatar';
+	update_option( 'fair_settings', $fair_settings );
+}
+
+// Kick it off.
+bootstrap();

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -25,7 +25,7 @@ function set_default_fair_avatar_to_gravatar() {
 
 	// Check for FAIR settings.
 	$fair_settings = get_option( 'fair_settings', [] );
-	if ( empty( $fair_settings ) ) {
+	if ( ! empty( $fair_settings ) ) {
 		return;
 	}
 

--- a/pantheon.php
+++ b/pantheon.php
@@ -16,6 +16,7 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';
 	require_once 'inc/pantheon-page-cache.php';
 	require_once 'inc/site-health.php';
+	require_once 'inc/settings.php';
 	if ( ! defined( 'DISABLE_PANTHEON_UPDATE_NOTICES' ) || ! DISABLE_PANTHEON_UPDATE_NOTICES ) {
 		require_once 'inc/pantheon-updates.php';
 	}


### PR DESCRIPTION
This PR adds a new `settings.php` include component for Pantheon settings overrides. This facilitates the addition to automatically (via the mu-plugin) default the avatar settings on installs with the FAIR plugin installed to use Gravatar instead of locally-uploaded avatar files. This makes the integration of the FAIR plugin seamless for https://github.com/pantheon-systems/WordPress/pull/419 and https://github.com/pantheon-systems/wordpress-composer-managed/pull/188.

The avatar setting can still be updated via the FAIR Settings menu.

Discussion for implementation of FAIR into Pantheon WordPress upstreams broadly should happen in https://github.com/pantheon-systems/WordPress/pull/419.