### PR TITLE
Improve Site Health check for plans without Redis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install Composer dependencies
         run: |
           if [ ${{ matrix.php_version }} = "7.4" ]; then
+            composer require pantheon-systems/pantheon-wp-coding-standards:^2.0 --dev --no-update
             composer update
           fi
           composer install

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "vlucas/phpdotenv": "*"
   },
   "require-dev": {
-    "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
+    "pantheon-systems/pantheon-wp-coding-standards": "^3.0",
     "pantheon-systems/wpunit-helpers": "^2.0",
     "phpunit/phpunit": "^9",
     "yoast/phpunit-polyfills": "^2.0"

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -16,3 +16,34 @@ function _pantheon_get_current_wordpress_version(): string {
 	include ABSPATH . WPINC . '/version.php';
 	return $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 }
+
+/**
+ * Helper function to get the request headers.
+ *
+ * @param array $headers Optional. An array of headers to process. Defaults to $_SERVER.
+ * @return array Processed headers in standard HTTP header format.
+ */
+function _pantheon_get_request_headers( array $headers = [] ): array {
+	$headers = ! empty( $headers ) ? $headers : ( ! empty( $_SERVER ) ? $_SERVER : [] );
+
+	if ( empty( $headers ) ) {
+		return [];
+	}
+
+	foreach ( $headers as $key => $value ) {
+		if ( substr( $key, 0, 5 ) !== 'HTTP_' ) {
+			continue;
+		}
+
+		/**
+		 * Convert HTTP headers to standard HTTP header format.
+		 *
+		 * We use str_replace twice so that we can use ucwords to capitalize
+		 * the first letter of each word, e.g. HTTP_USER_AGENT to User-Agent.
+		 */
+		$header = str_replace( ' ', '-', ucwords( str_replace( '_', ' ', strtolower( substr( $key, 5 ) ) ) ) );
+		$headers[ $header ] = $value;
+	}
+
+	return $headers;
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -47,3 +47,14 @@ function _pantheon_get_request_headers( array $headers = [] ): array {
 
 	return $headers;
 }
+
+/**
+ * Helper function to get a specific header value.
+ *
+ * @param string $key The header key to retrieve.
+ * @return string The value of the specified header, or an empty string if not found.
+ */
+function _pantheon_get_header( string $key ): string {
+	$headers = _pantheon_get_request_headers();
+	return ! empty( $headers[ $key ] ) ? esc_textarea( $headers[ $key ] ) : '';
+}

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -89,8 +89,11 @@ function _pantheon_upstream_update_notice() {
 	$div_style = esc_attr( 'display: table;' );
 	$paragraph_style = esc_attr( 'font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;' );
 
+	/**
+	 * If WP core is out of date, alter the message and show the nag
+	 * everywhere.
+	 */
 	if ( ! _pantheon_is_wordpress_core_latest() ) {
-		// If WP core is out of date, alter the message and show the nag everywhere.
 		// Translators: %s is a URL to the user's Pantheon Dashboard.
 		$notice_message = sprintf( __( 'A new WordPress update is available! Please update from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] );
 	}
@@ -157,8 +160,10 @@ function _pantheon_disable_wp_updates(): object {
 	];
 }
 
-// In the Test and Live environments, clear plugin/theme update notifications.
-// Users must check a dev or multidev environment for updates.
+/**
+ * In the Test and Live environments, clear plugin/theme update notifications.
+ * Users must check a dev or multidev environment for updates.
+ */
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && in_array( $_ENV['PANTHEON_ENVIRONMENT'], [ 'test', 'live' ], true ) && ( php_sapi_name() !== 'cli' ) ) {
 
 	// Disable Plugin Updates.

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -939,8 +939,8 @@ function test_object_cache() {
 	}
 
 	/**
-	 * If the service level is basic, we cannot use
-	 * Redis. Bail early, this test is not helpful.
+	 * If the service level is basic, we cannot use Redis. Bail early, this
+	 * test is not helpful.
 	 */
 	if ( in_array( $service_level, $redis_unavailable, true ) ) {
 		return [];

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -965,9 +965,11 @@ function test_object_cache() {
 		return $result;
 	}
 
+	// Redis is available and active. Check which object cache plugin is active.
 	$wp_redis_active = is_plugin_active( 'wp-redis/wp-redis.php' );
 	$ocp_active = is_plugin_active( 'object-cache-pro/object-cache-pro.php' );
 
+	// If WP Redis is active, we recommend using Object Cache Pro.
 	if ( $wp_redis_active ) {
 		$result = [
 			'label' => __( 'WP Redis Active', 'pantheon' ),
@@ -988,6 +990,7 @@ function test_object_cache() {
 		return $result;
 	}
 
+	// If Object Cache Pro is active, we can return a good status.
 	if ( $ocp_active ) {
 		$result = [
 			'label' => __( 'Object Cache Pro Active', 'pantheon' ),
@@ -1008,6 +1011,7 @@ function test_object_cache() {
 		return $result;
 	}
 
+	// Redis is active but no object cache plugin is installed. Recommend OCP.
 	$result = [
 		'label' => __( 'No Object Cache Plugin Active', 'pantheon' ),
 		'status' => 'critical',

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -952,7 +952,7 @@ function test_object_cache() {
 			'label' => __( 'Redis Object Cache', 'pantheon' ),
 			'status' => 'critical',
 			'badge' => [
-				'label' => __( 'Performance', 'pantheon' ),
+				'label' => __( 'Pantheon', 'pantheon' ),
 				'color' => 'red',
 			],
 			'description' => sprintf(
@@ -973,7 +973,7 @@ function test_object_cache() {
 			'label' => __( 'WP Redis Active', 'pantheon' ),
 			'status' => 'recommended',
 			'badge' => [
-				'label' => __( 'Performance', 'pantheon' ),
+				'label' => __( 'Pantheon', 'pantheon' ),
 				'color' => 'orange',
 			],
 			'description' => sprintf(
@@ -993,8 +993,8 @@ function test_object_cache() {
 			'label' => __( 'Object Cache Pro Active', 'pantheon' ),
 			'status' => 'good',
 			'badge' => [
-				'label' => __( 'Performance', 'pantheon' ),
-				'color' => 'green',
+				'label' => __( 'Pantheon', 'pantheon' ),
+				'color' => 'blue',
 			],
 			'description' => sprintf(
 				'<p>%s</p><p>%s</p>',
@@ -1012,7 +1012,7 @@ function test_object_cache() {
 		'label' => __( 'No Object Cache Plugin Active', 'pantheon' ),
 		'status' => 'critical',
 		'badge' => [
-			'label' => __( 'Performance', 'pantheon' ),
+			'label' => __( 'Pantheon', 'pantheon' ),
 			'color' => 'red',
 		],
 		'description' => sprintf(

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -928,7 +928,35 @@ function object_cache_tests( $tests ) {
  * @return array
  */
 function test_object_cache() {
-	if ( ! isset( $_ENV['CACHE_HOST'] ) ) {
+	$cache_host = isset( $_ENV['CACHE_HOST'] ) ? $_ENV['CACHE_HOST'] : null;
+	$service_level = isset( $_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] ) ? $_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] : null;
+	$redis_unavailable = [ 'basic', 'basic_small' ];
+
+	/**
+	 * If Redis is unavailable, the CACHE_HOST will not exist and the service
+	 * level will be basic.
+	 */
+	if ( ! $cache_host && in_array( $service_level, $redis_unavailable, true ) ) {
+		$result = [
+			'label' => __( 'Redis Object Cache Unavailable for Your Plan', 'pantheon' ),
+			'status' => 'good',
+			'badge' => [
+				'label' => __( 'Performance', 'pantheon' ),
+				'color' => 'green',
+			],
+			'description' => sprintf(
+				'<p>%1$s</p><p>%2$s</p>',
+				__( 'Redis object cache is not available for Basic plans. We recommend upgrading your plan if you would like to make use of Redis object caching.', 'pantheon' ),
+				sprintf( __( 'For more information see our <a href="%s">Object Cache documentation</a>.', 'pantheon' ), 'https://docs.pantheon.io/object-cache' )
+			),
+			'test' => 'object_cache',
+		];
+
+		return $result;
+	}
+
+	// Redis is available on the plan, but not active.
+	if ( ! $cache_host ) {
 		$result = [
 			'label' => __( 'Redis Object Cache', 'pantheon' ),
 			'status' => 'critical',

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -933,16 +933,16 @@ function test_object_cache() {
 	$service_level = _pantheon_get_header( 'Pcontext-Service-Level' );
 	$redis_unavailable = [ 'basic', 'basic_small' ];
 
-	// If we can't find a service level or cache host, bail early.
+	// If we can't find a service level nor cache host, bail early.
 	if ( ! $service_level && ! $cache_host ) {
 		return [];
 	}
 
 	/**
-	 * If Redis is unavailable and the service level is basic, we cannot use
+	 * If the service level is basic, we cannot use
 	 * Redis. Bail early, this test is not helpful.
 	 */
-	if ( ! $cache_host && in_array( $service_level, $redis_unavailable, true ) ) {
+	if ( in_array( $service_level, $redis_unavailable, true ) ) {
 		return [];
 	}
 

--- a/inc/site-health.php
+++ b/inc/site-health.php
@@ -947,6 +947,7 @@ function test_object_cache() {
 			'description' => sprintf(
 				'<p>%1$s</p><p>%2$s</p>',
 				__( 'Redis object cache is not available for Basic plans. We recommend upgrading your plan if you would like to make use of Redis object caching.', 'pantheon' ),
+				// Translators: %s is a URL to the Pantheon documentation for Object Cache.
 				sprintf( __( 'For more information see our <a href="%s">Object Cache documentation</a>.', 'pantheon' ), 'https://docs.pantheon.io/object-cache' )
 			),
 			'test' => 'object_cache',

--- a/pantheon.php
+++ b/pantheon.php
@@ -40,8 +40,12 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		 */
 		define( 'FS_METHOD', 'direct' );
 	}
-	// When developing a WordPress Multisite locally, ensure that this constant is set.
-	// This will set the Multisite variable in all Pantheon environments.
+
+	/**
+	 * When developing a WordPress Multisite locally, ensure that this constant 
+	 * is set.
+	 * This will set the Multisite variable in all Pantheon environments.
+	 */
 	if ( getenv( 'FRAMEWORK' ) === 'wordpress_network' && ! defined( 'WP_ALLOW_MULTISITE' ) ) {
 		define( 'WP_ALLOW_MULTISITE', true );
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -68,5 +68,9 @@
 		<exclude name="Generic.Commenting.DocComment.MissingShort">
 			<exclude-pattern>inc/pantheon-page-cache.php</exclude-pattern>
 		</exclude>
+
+		<exclude name="Pantheon_WP.Commenting.DisallowMultilineSlashComment.LongLine">
+			<exclude-pattern>inc/network/includes-network.php</exclude-pattern>
+		</exclude>
 	</rule>
 </ruleset>

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -56,7 +56,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 
 	public function test_object_cache_no_redis_unavailable() {
 		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'basic';
-		unset($_ENV['CACHE_HOST']);
+		unset( $_ENV['CACHE_HOST'] );
 
 		$result = Pantheon\Site_Health\test_object_cache();
 		$this->assertEquals( 'good', $result['status'] );

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -56,11 +56,11 @@ class Test_Site_Health extends WP_UnitTestCase {
 
 	public function test_object_cache_no_redis_unavailable() {
 		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'basic';
-		$_ENV['CACHE_HOST'] = null;
+		unset($_ENV['CACHE_HOST']);
 
 		$result = Pantheon\Site_Health\test_object_cache();
 		$this->assertEquals( 'good', $result['status'] );
-		$this->assertStringContainsString( 'Redis object cache is not available for Basic plans. We recommend upgrading your plan if you would like to make use of Redis object caching.', $result['description'] );
+		$this->assertContains( 'Redis object cache is not available for Basic plans.', $result['description'] );
 	}
 
 	public function test_object_cache_no_redis() {

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -60,7 +60,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 
 		$result = Pantheon\Site_Health\test_object_cache();
 		$this->assertEquals( 'good', $result['status'] );
-		$this->assertContains( 'Redis object cache is not available for Basic plans.', $result['description'] );
+		$this->assertStringContainsString( 'Redis object cache is not available for Basic plans.', $result['description'] );
 	}
 
 	public function test_object_cache_no_redis() {

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -55,12 +55,23 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_no_redis_unavailable() {
-		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'basic';
+		$_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'basic';
 		unset( $_ENV['CACHE_HOST'] );
 
 		$result = Pantheon\Site_Health\test_object_cache();
-		$this->assertEquals( 'good', $result['status'] );
-		$this->assertStringContainsString( 'Redis object cache is not available for Basic plans.', $result['description'] );
+		
+		// Result should be empty for basic plans without Redis.
+		$this->assertEmpty( $result );
+	}
+
+	public function test_object_cache_no_headers() {
+		unset( $_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] );
+		unset( $_ENV['CACHE_HOST'] );
+
+		$result = Pantheon\Site_Health\test_object_cache();
+
+		// Result should be empty when no headers are set.
+		$this->assertEmpty( $result );
 	}
 
 	public function test_object_cache_no_redis() {

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -64,7 +64,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_no_redis() {
-		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
+		$_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$result = Pantheon\Site_Health\test_object_cache();
 
 		$this->assertEquals( 'critical', $result['status'] );
@@ -72,7 +72,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_redis_no_plugin() {
-		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
+		$_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 
 		$result = Pantheon\Site_Health\test_object_cache();
@@ -82,7 +82,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_wpredis_active() {
-		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
+		$_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'wp-redis/wp-redis.php' );
 
@@ -93,7 +93,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_ocp_active() {
-		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
+		$_SERVER['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'object-cache-pro/object-cache-pro.php' );
 

--- a/tests/phpunit/test-site-health.php
+++ b/tests/phpunit/test-site-health.php
@@ -54,7 +54,17 @@ class Test_Site_Health extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'background_updates', $result['async'] );
 	}
 
+	public function test_object_cache_no_redis_unavailable() {
+		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'basic';
+		$_ENV['CACHE_HOST'] = null;
+
+		$result = Pantheon\Site_Health\test_object_cache();
+		$this->assertEquals( 'good', $result['status'] );
+		$this->assertStringContainsString( 'Redis object cache is not available for Basic plans. We recommend upgrading your plan if you would like to make use of Redis object caching.', $result['description'] );
+	}
+
 	public function test_object_cache_no_redis() {
+		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$result = Pantheon\Site_Health\test_object_cache();
 
 		$this->assertEquals( 'critical', $result['status'] );
@@ -62,6 +72,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_redis_no_plugin() {
+		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 
 		$result = Pantheon\Site_Health\test_object_cache();
@@ -71,6 +82,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_wpredis_active() {
+		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'wp-redis/wp-redis.php' );
 
@@ -81,6 +93,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	public function test_object_cache_with_ocp_active() {
+		$_ENV['HTTP_PCONTEXT_SERVICE_LEVEL'] = 'performance_small';
 		$_ENV['CACHE_HOST'] = 'cacheserver'; // Ensure CACHE_HOST is set.
 		$this->set_active_plugin( 'object-cache-pro/object-cache-pro.php' );
 


### PR DESCRIPTION
Enhance the Site Health page to not display any report if user is on a Basic plan where Redis is unavailable, reducing confusion for users. 

This implementation relies on headers sent by GCDN. If the headers are not present at all, the tests fail gracefully and do not run sit health tests at all.

Included in this implementation is some code that originally was written for [Edge Integrations](https://github.com/pantheon-systems/pantheon-edge-integrations/blob/main/src/HeaderData.php#L38-L73) that allows us to pull the HTTP headers out of the `$_SERVER` superglobal and pluck the value of specific headers. Providing this function in the mu-plugin can be helpful for our future selves or customers building things similar to EI.

Tests have been added to verify this behavior and refine existing tests for compatibility with the new checks.

This PR also bumps the version of the Pantheon WP Coding Standards and applies fixes for the new rules added in 3.0.

fixes #95