### PR TITLE
[SITE-5654] Add Independent Analytics compatibility layer

### DIFF
--- a/inc/compatibility/class-acceleratedmobilepages.php
+++ b/inc/compatibility/class-acceleratedmobilepages.php
@@ -22,6 +22,7 @@ class AcceleratedMobilePages extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class AcceleratedMobilePages extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-auth0.php
+++ b/inc/compatibility/class-auth0.php
@@ -22,6 +22,7 @@ class Auth0 extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class Auth0 extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-autoptimize.php
+++ b/inc/compatibility/class-autoptimize.php
@@ -22,6 +22,7 @@ class Autoptimize extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class Autoptimize extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-bettersearchreplace.php
+++ b/inc/compatibility/class-bettersearchreplace.php
@@ -22,6 +22,7 @@ class BetterSearchReplace extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -31,6 +32,7 @@ class BetterSearchReplace extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-brokenlinkchecker.php
+++ b/inc/compatibility/class-brokenlinkchecker.php
@@ -22,6 +22,7 @@ class BrokenLinkChecker extends Base {
 	private $default_threshold_value = 72;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class BrokenLinkChecker extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-compatibilityfactory.php
+++ b/inc/compatibility/class-compatibilityfactory.php
@@ -89,6 +89,8 @@ class CompatibilityFactory {
 			EventEspresso::class => [ 'slug' => 'event-espresso-decaf/espresso.php' ],
 			FastVelocityMinify::class => [ 'slug' => 'fast-velocity-minify/fvm.php' ],
 			ForceLogin::class => [ 'slug' => 'wp-force-login/wp-force-login.php' ],
+			IndependentAnalytics::class => [ 'slug' => 'independent-analytics/iawp.php' ],
+			IndependentAnalyticsPro::class => [ 'slug' => 'independent-analytics-pro/iawp.php' ],
 			OfficialFacebookPixel::class => [ 'slug' => 'official-facebook-pixel/facebook-for-wordpress.php' ],
 			Polylang::class => [ 'slug' => 'polylang/polylang.php' ],
 			Redirection::class => [ 'slug' => 'redirection/redirection.php' ],
@@ -166,6 +168,8 @@ class CompatibilityFactory {
 		$constant_fixes = [
 			ContactFormSeven::class,
 			FastVelocityMinify::class,
+			IndependentAnalytics::class,
+			IndependentAnalyticsPro::class,
 			Polylang::class,
 			WooZone::class,
 			Autoptimize::class,

--- a/inc/compatibility/class-contactformseven.php
+++ b/inc/compatibility/class-contactformseven.php
@@ -23,6 +23,7 @@ class ContactFormSeven extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -31,6 +32,7 @@ class ContactFormSeven extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-fastvelocityminify.php
+++ b/inc/compatibility/class-fastvelocityminify.php
@@ -22,6 +22,7 @@ class FastVelocityMinify extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-forcelogin.php
+++ b/inc/compatibility/class-forcelogin.php
@@ -22,6 +22,7 @@ class ForceLogin extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class ForceLogin extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-independentanalytics.php
+++ b/inc/compatibility/class-independentanalytics.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Compatibility fix for Independent Analytics plugin.
+ *
+ * @link https://github.com/pantheon-systems/pantheon-mu-plugin/issues/110
+ * @package Pantheon\Compatibility
+ */
+
+namespace Pantheon\Compatibility;
+
+use Pantheon\Compatibility\Fixes\DefineConstantFix;
+
+/**
+ * Class IndependentAnalytics
+ */
+class IndependentAnalytics extends Base {
+	/**
+	 * Run fix on each request.
+	 *
+	 * @var bool
+	 */
+	protected $run_fix_everytime = true;
+
+	/**
+	 * @return void
+	 */
+	public function apply_fix() {
+		DefineConstantFix::apply( 'IAWP_TEMP_DIR', '/code/wp-content/uploads/iawp/' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function remove_fix() {}
+}

--- a/inc/compatibility/class-independentanalytics.php
+++ b/inc/compatibility/class-independentanalytics.php
@@ -22,6 +22,7 @@ class IndependentAnalytics extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-independentanalyticspro.php
+++ b/inc/compatibility/class-independentanalyticspro.php
@@ -22,6 +22,7 @@ class IndependentAnalyticsPro extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-independentanalyticspro.php
+++ b/inc/compatibility/class-independentanalyticspro.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Compatibility fix for Independent Analytics Pro plugin.
+ *
+ * @link https://github.com/pantheon-systems/pantheon-mu-plugin/issues/110
+ * @package Pantheon\Compatibility
+ */
+
+namespace Pantheon\Compatibility;
+
+use Pantheon\Compatibility\Fixes\DefineConstantFix;
+
+/**
+ * Class IndependentAnalyticsPro
+ */
+class IndependentAnalyticsPro extends Base {
+	/**
+	 * Run fix on each request.
+	 *
+	 * @var bool
+	 */
+	protected $run_fix_everytime = true;
+
+	/**
+	 * @return void
+	 */
+	public function apply_fix() {
+		DefineConstantFix::apply( 'IAWP_TEMP_DIR', '/code/wp-content/uploads/iawp/' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function remove_fix() {}
+}

--- a/inc/compatibility/class-officialfacebookpixel.php
+++ b/inc/compatibility/class-officialfacebookpixel.php
@@ -22,6 +22,7 @@ class OfficialFacebookPixel extends Base {
 	protected $run_on_plugin_activation = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-polylang.php
+++ b/inc/compatibility/class-polylang.php
@@ -22,6 +22,7 @@ class Polylang extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-redirection.php
+++ b/inc/compatibility/class-redirection.php
@@ -22,6 +22,7 @@ class Redirection extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class Redirection extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-sliderrevolution.php
+++ b/inc/compatibility/class-sliderrevolution.php
@@ -22,6 +22,7 @@ class SliderRevolution extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-tweetoldpost.php
+++ b/inc/compatibility/class-tweetoldpost.php
@@ -22,6 +22,7 @@ class TweetOldPost extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class TweetOldPost extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-woozone.php
+++ b/inc/compatibility/class-woozone.php
@@ -22,6 +22,7 @@ class WooZone extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {

--- a/inc/compatibility/class-wprocket.php
+++ b/inc/compatibility/class-wprocket.php
@@ -24,6 +24,7 @@ class WPRocket extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -31,6 +32,7 @@ class WPRocket extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/class-yithwoocommerce.php
+++ b/inc/compatibility/class-yithwoocommerce.php
@@ -22,6 +22,7 @@ class YITHWoocommerce extends Base {
 	protected $run_fix_everytime = true;
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function apply_fix() {
@@ -29,6 +30,7 @@ class YITHWoocommerce extends Base {
 	}
 
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public function remove_fix() {

--- a/inc/compatibility/fixes/class-acceleratedmobilepagesfix.php
+++ b/inc/compatibility/fixes/class-acceleratedmobilepagesfix.php
@@ -18,6 +18,7 @@ use function extension_loaded;
  */
 class AcceleratedMobilePagesFix {
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public static function apply() {

--- a/inc/compatibility/fixes/class-autoptimizefix.php
+++ b/inc/compatibility/fixes/class-autoptimizefix.php
@@ -17,6 +17,7 @@ class AutoptimizeFix {
 	/**
 	 * Apply the fix
 	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public static function apply() {

--- a/inc/compatibility/fixes/class-selfupdatingthemesfix.php
+++ b/inc/compatibility/fixes/class-selfupdatingthemesfix.php
@@ -14,6 +14,7 @@ use const ABSPATH;
  */
 class SelfUpdatingThemesFix {
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public static function apply() {

--- a/inc/compatibility/fixes/class-wprocketfix.php
+++ b/inc/compatibility/fixes/class-wprocketfix.php
@@ -13,6 +13,7 @@ namespace Pantheon\Compatibility\Fixes;
  */
 class WPRocketFix {
 	/**
+	 * @SuppressWarnings(PHPMD.StaticAccess)
 	 * @return void
 	 */
 	public static function apply() {

--- a/tests/phpunit/test-compatibility-layer.php
+++ b/tests/phpunit/test-compatibility-layer.php
@@ -112,8 +112,8 @@ class Test_Compatibility_Layer extends WP_UnitTestCase {
 
 	public function test_independent_analytics_defines_constant() {
 		$this->set_active_plugin( 'independent-analytics/iawp.php' );
-		$ia = new \Pantheon\Compatibility\IndependentAnalytics( 'independent-analytics/iawp.php' );
-		$ia->apply_fix();
+		$iawp = new \Pantheon\Compatibility\IndependentAnalytics( 'independent-analytics/iawp.php' );
+		$iawp->apply_fix();
 
 		$this->assertTrue( defined( 'IAWP_TEMP_DIR' ) );
 		$this->assertSame( '/code/wp-content/uploads/iawp/', IAWP_TEMP_DIR );

--- a/tests/phpunit/test-compatibility-layer.php
+++ b/tests/phpunit/test-compatibility-layer.php
@@ -110,6 +110,29 @@ class Test_Compatibility_Layer extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Incompatible', $review_table );
 	}
 
+	public function test_independent_analytics_defines_constant() {
+		$this->set_active_plugin( 'independent-analytics/iawp.php' );
+		$ia = new \Pantheon\Compatibility\IndependentAnalytics( 'independent-analytics/iawp.php' );
+		$ia->apply_fix();
+
+		$this->assertTrue( defined( 'IAWP_TEMP_DIR' ) );
+		$this->assertSame( '/code/wp-content/uploads/iawp/', IAWP_TEMP_DIR );
+	}
+
+	public function test_independent_analytics_registers_deactivation_hook() {
+		$this->set_active_plugin( 'independent-analytics/iawp.php' );
+		new \Pantheon\Compatibility\IndependentAnalytics( 'independent-analytics/iawp.php' );
+		global $wp_filter;
+		$this->assertTrue( array_key_exists( 'deactivate_independent-analytics/iawp.php', $wp_filter ) );
+	}
+
+	public function test_independent_analytics_pro_registers_deactivation_hook() {
+		$this->set_active_plugin( 'independent-analytics-pro/iawp.php' );
+		new \Pantheon\Compatibility\IndependentAnalyticsPro( 'independent-analytics-pro/iawp.php' );
+		global $wp_filter;
+		$this->assertTrue( array_key_exists( 'deactivate_independent-analytics-pro/iawp.php', $wp_filter ) );
+	}
+
 	/**
 	 * Test that persist_data preserves the original timestamp across multiple calls.
 	 */


### PR DESCRIPTION
## Summary
- Adds auto-resolution for the [Independent Analytics](https://wordpress.org/plugins/independent-analytics/) plugin on Pantheon by defining the `IAWP_TEMP_DIR` constant to redirect the plugin's temp directory (`template-cache`, `device-detector.json`) to the writable uploads folder (`/code/wp-content/uploads/iawp/`).
- Handles both the free (`independent-analytics`) and pro (`independent-analytics-pro`) plugin variants.
- Registers both as constant fixes so the constant is defined early at `muplugins_loaded`.

## Test plan
- [ ] Activate Independent Analytics (free) on a Pantheon site and verify `IAWP_TEMP_DIR` is defined as `/code/wp-content/uploads/iawp/`
- [ ] Confirm the plugin creates its `template-cache` and `device-data-cache` subdirectories inside the uploads path
- [ ] Verify the plugin no longer throws BladeOne errors related to the non-writable plugin directory
- [ ] Activate Independent Analytics Pro and verify the same constant fix applies
- [ ] Deactivate either plugin and confirm the compatibility entry is removed from `pantheon_applied_fixes`
- [ ] Confirm the fix appears under "Automatic Fixes" in Site Health > Pantheon Compatibility

Closes #110