### PR TITLE
Add automated release workflow & fix failing tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Description
+
+<!-- Describe the change and why it's needed. -->
+
+## Related Issues / Tickets
+
+<!-- Link to any related GitHub issues or internal tickets. -->
+
+## Testing
+
+<!-- Describe how you tested this change. -->
+
+---
+
+## Release Reminder
+
+Releases are gated by the version in `pantheon.php`. Before merging:
+
+| Intent | What to do |
+|---|---|
+| Normal PR (no release) | Leave version as `X.Y.Z-dev` — no action needed |
+| **Ship a release with this PR** | Remove `-dev` from the version (e.g. `1.5.7-dev` → `1.5.7`) |
+| **Ship a minor version** | Update version to the target minor (e.g. `1.5.7-dev` → `1.6.0`) |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Releases are gated by the version in `pantheon.php`. Before merging:
 
 | Intent | What to do |
 |---|---|
-| Normal PR (no release) | Leave version as `X.Y.Z-dev` — no action needed |
+| Normal PR (no release) | Leave version as `X.Y.Z-dev` — no action needed. If this is a minor bump but you're not ready to release, Update the version to the target minor but leave the `-dev` suffix. |
 | **Ship a release with this PR** | Remove `-dev` from the version (e.g. `1.5.7-dev` → `1.5.7`) |
 | **Ship a minor version** | Update version to the target minor (e.g. `1.5.7-dev` → `1.6.0`) |
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Tag, Release, and Version Bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Read version from pantheon.php
+        id: version
+        run: |
+          VERSION=$(grep -oP "define\( 'PANTHEON_MU_PLUGIN_VERSION', '\K[^']+" pantheon.php)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Check whether this is a release version
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" == *-dev ]]; then
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION ends in -dev — skipping release."
+          else
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION is a release candidate — proceeding."
+          fi
+
+      - name: Configure git identity
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          git config user.email "bot@getpantheon.com"
+          git config user.name "Pantheon Robot"
+
+      - name: Create Git tag
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "$VERSION" \
+            --generate-notes \
+            --title "$VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute next dev version
+        if: steps.check.outputs.is_release == 'true'
+        id: next
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT_PATCH=$(( PATCH + 1 ))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-dev"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Next dev version: $NEXT_VERSION"
+
+      - name: Bump version in pantheon.php
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          NEXT="${{ steps.next.outputs.next_version }}"
+          sed -i "s/^\( \* Version: \).*/\1${NEXT}/" pantheon.php
+          sed -i "s/\(define( 'PANTHEON_MU_PLUGIN_VERSION', '\)[^']*\(.*\)/\1${NEXT}\2/" pantheon.php
+
+      - name: Verify both version strings were updated
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          NEXT="${{ steps.next.outputs.next_version }}"
+          COUNT=$(grep -c "$NEXT" pantheon.php)
+          if [ "$COUNT" -lt 2 ]; then
+            echo "ERROR: Expected at least 2 occurrences of $NEXT in pantheon.php, found $COUNT"
+            grep -n "Version\|PANTHEON_MU_PLUGIN_VERSION" pantheon.php
+            exit 1
+          fi
+          echo "Both version strings updated to $NEXT"
+          grep -n "Version\|PANTHEON_MU_PLUGIN_VERSION" pantheon.php
+
+      - name: Open version bump PR
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          NEXT="${{ steps.next.outputs.next_version }}"
+          BRANCH="chore/bump-version-${NEXT}"
+          git checkout -b "$BRANCH"
+          git add pantheon.php
+          git commit -m "chore: bump version to ${NEXT}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump version to ${NEXT}" \
+            --body "Automated version bump after release. Merges automatically." \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: Test
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - '**'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Update both version strings in `pantheon.php` on your PR before merging:
 | Minor release | `1.5.7-dev` → `1.6.0` |
 | Major release | `1.5.7-dev` → `2.0.0` |
 
-After a release, automation sets the working version to the next patch `-dev`. If the next release should be a minor or major bump, update `pantheon.php` again on a subsequent PR.
+After a release, automation sets the working version to the next patch `-dev`.
 
 ### Manual steps that remain
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ After a release, automation sets the working version to the next patch `-dev`. I
 
 ### Manual steps that remain
 
-If new files were added that should be excluded from the WordPress upstream, add them to `.gitattributes` with `export-ignore` and update the `$files_to_delete` array in [`update-tool/src/Update/Filters/CopyMuPlugin.php`](https://github.com/pantheon-systems/update-tool/blob/master/src/Update/Filters/CopyMuPlugin.php).
+If new files were added that should be excluded from the WordPress upstream, add them to `.gitattributes` with `export-ignore`.
 
 ## Contributing to the Compatibility Layer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,40 @@ Because the WordPress upstream is only updated when a new WordPress release is c
 
 ## Release Process
 
-When you are ready for a new `pantheon-mu-plugin` release, before cutting a new release, there are a few steps that need to be taken before you do so.
+Releases are automated via GitHub Actions and gated by the version string in `pantheon.php`.
 
-1. Update the version number in `pantheon.php` in the plugin header and the `PANTHEON_MU_PLUGIN_VERSION` constant.
-1. If there were any new files that were added to the plugin that should be excluded from the WordPress upstream, add them to the `.gitattributes` file with `export-ignore` and be sure to add them to the `$files_to_delete` array in [`update-tool/src/Update/Filters/CopyMuPlugin.php`](https://github.com/pantheon-systems/update-tool/blob/master/src/Update/Filters/CopyMuPlugin.php).
-1. Use the GitHub UI to create a new release. The tag should be the version number only (not prefixed with `v`, e.g. `1.2.1`). Use the GitHub tools to autocomplete the title and body of the release with the changelog. The release should be created from the `main` branch.
+### How it works
+
+The version appears in two places in `pantheon.php` that must always match:
+
+1. The plugin header comment: `* Version: 1.5.7-dev`
+2. The PHP constant: `define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.7-dev' );`
+
+When a commit lands on `main`, the release workflow reads the version and applies the following logic:
+
+- **Ends in `-dev`** (e.g. `1.5.7-dev`): do nothing. This is the normal working state.
+- **Does not end in `-dev`** (e.g. `1.5.7`): the workflow automatically:
+  1. Creates a Git tag for that version (no `v` prefix, per existing convention).
+  2. Publishes a GitHub Release with auto-generated release notes.
+  3. Increments the patch version and appends `-dev` (e.g. `1.5.7` → `1.5.8-dev`), updating both occurrences in `pantheon.php`.
+  4. Opens a PR with the bump and enables auto-merge — it merges automatically.
+
+### Shipping a release
+
+Update both version strings in `pantheon.php` on your PR before merging:
+
+| Goal | Change in `pantheon.php` |
+|---|---|
+| No release (normal PR) | Leave as `X.Y.Z-dev` |
+| Patch release | `1.5.7-dev` → `1.5.7` |
+| Minor release | `1.5.7-dev` → `1.6.0` |
+| Major release | `1.5.7-dev` → `2.0.0` |
+
+After a release, automation sets the working version to the next patch `-dev`. If the next release should be a minor or major bump, update `pantheon.php` again on a subsequent PR.
+
+### Manual steps that remain
+
+If new files were added that should be excluded from the WordPress upstream, add them to `.gitattributes` with `export-ignore` and update the `$files_to_delete` array in [`update-tool/src/Update/Filters/CopyMuPlugin.php`](https://github.com/pantheon-systems/update-tool/blob/master/src/Update/Filters/CopyMuPlugin.php).
 
 ## Contributing to the Compatibility Layer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ When a commit lands on `main`, the release workflow reads the version and applie
   1. Creates a Git tag for that version (no `v` prefix, per existing convention).
   2. Publishes a GitHub Release with auto-generated release notes.
   3. Increments the patch version and appends `-dev` (e.g. `1.5.7` → `1.5.8-dev`), updating both occurrences in `pantheon.php`.
-  4. Opens a PR with the bump and enables auto-merge — it merges automatically.
+  4. Opens a PR with the bump and enables auto-merge.
 
 ### Shipping a release
 

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -125,22 +125,9 @@ WP_CLI::add_hook( 'before_invoke:elasticpress', function () {
 	}
 
 	if ( ! defined( 'WP_HOME' ) || strpos( WP_HOME, 'http://' ) === 0 ) {
-		add_filter( 'option_home', '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( 'option_home', '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 	if ( ! defined( 'WP_SITEURL' ) || strpos( WP_SITEURL, 'http://' ) === 0 ) {
-		add_filter( 'option_siteurl', '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( 'option_siteurl', '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 } );
-
-/**
- * Replace http:// with https:// in a URL string.
- *
- * @param string $url The option value.
- * @return string The URL with https:// scheme.
- */
-function _pantheon_ep_force_https_url( $url ) {
-	if ( is_string( $url ) && strpos( $url, 'http://' ) === 0 ) {
-		return 'https://' . substr( $url, 7 );
-	}
-	return $url;
-}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -170,3 +170,16 @@ function _pantheon_enqueue_notice_styles() {
 	);
 }
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\_pantheon_enqueue_notice_styles' );
+
+/**
+ * Replace http:// with https:// at the start of a URL string.
+ *
+ * @param mixed $url The option value.
+ * @return mixed The URL with https:// scheme, or the original value if not an http:// string.
+ */
+function _pantheon_ep_force_https_url( $url ) {
+	if ( is_string( $url ) && strpos( $url, 'http://' ) === 0 ) {
+		return 'https://' . substr( $url, 7 );
+	}
+	return $url;
+}

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.5.4
+ * Version: 1.5.7-dev
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.4' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.7-dev' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';

--- a/tests/phpunit/test-elasticpress-cli.php
+++ b/tests/phpunit/test-elasticpress-cli.php
@@ -40,7 +40,7 @@ class Test_ElasticPress_CLI extends WP_UnitTestCase {
 	public function test_force_https_url( $input, $expected ) {
 		$this->assertSame(
 			$expected,
-			\Pantheon\CLI\_pantheon_ep_force_https_url( $input )
+			\Pantheon\_pantheon_ep_force_https_url( $input )
 		);
 	}
 
@@ -74,9 +74,9 @@ class Test_ElasticPress_CLI extends WP_UnitTestCase {
 	 */
 	public function test_option_filter_forces_https( $option ) {
 		$filter_name = 'option_' . $option;
-		add_filter( $filter_name, '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( $filter_name, '\\Pantheon\\_pantheon_ep_force_https_url' );
 		update_option( $option, 'http://example.com' );
 		$this->assertEquals( 'https://example.com', get_option( $option ) );
-		remove_filter( $filter_name, '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		remove_filter( $filter_name, '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 }

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -131,7 +131,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 		_pantheon_upstream_update_notice();
 		$output = ob_get_clean();
 	
-		$this->assertStringContainsString( 'Check for updates on', $output );
+		$this->assertStringContainsString( 'Check for Updates', $output );
 	}
 	
 	/**
@@ -144,26 +144,26 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 
 		set_current_screen( 'update-core' );
 	
-		// Simulate that the core is not the latest version.
+		// Simulate that the core is not the latest version by using a version higher than any installed WP.
 		set_site_transient(
 			'update_core',
 			(object) [
 				'updates' => [
 					(object) [
-						'current' => '6.3.1',
-						'response' => 'upgrade', 
+						'current' => '99.0.0',
+						'response' => 'upgrade',
 						'locale' => 'en_us',
 					],
 				],
-				'version_checked' => '6.2',
+				'version_checked' => self::$wp_version,
 			],
 		);
-	
+
 		ob_start();
 		_pantheon_upstream_update_notice();
 		$output = ob_get_clean();
-	
-		$this->assertStringContainsString( 'Check for updates on <a href="https://dashboard.pantheon.io/sites/test-site">your Pantheon dashboard</a>', $output );
+
+		$this->assertStringContainsString( 'A new WordPress update is available!', $output );
 	}
 	
 	/**


### PR DESCRIPTION
## Description

Implements automated release gating via GitHub Actions. The version string in `pantheon.php` controls whether a push to `main` triggers a release.

- **Version ends in `-dev`** → no-op, normal development state
- **Version has no `-dev` suffix** → workflow tags, publishes a GitHub Release with auto-generated notes, then opens an auto-merging PR bumping to the next patch `-dev`

## Changes

- **`pantheon.php`**: Bumped to `1.5.7-dev` (last manually released version was `1.5.6`)
- **`.github/workflows/release.yml`**: New release workflow using the native `gh` CLI (no third-party release action), SHA-pinned checkout
- **`.github/workflows/test.yml`**: Remove scheduled (daily) trigger — tests run on push only
- **`.github/PULL_REQUEST_TEMPLATE.md`**: New PR template with release reminder table
- **`CONTRIBUTING.md`**: Replaces manual release process docs with automated process docs

## How the release gate works

| Version in `pantheon.php` | What happens on merge to `main` |
|---|---|
| `X.Y.Z-dev` | Nothing — normal dev state |
| `X.Y.Z` (patch) | Tag + release + bump to `X.Y.Z+1-dev` PR |
| `X.Y.0` (minor) | Tag + release + bump to `X.Y.1-dev` PR |

The version bump is opened as a PR with auto-merge enabled. Since there are no required status checks on `main`, it merges immediately.

## Notes

- Uses `GITHUB_TOKEN` throughout — no PAT required
- Bot identity matches existing `lint.yml`: `bot@getpantheon.com` / `Pantheon Robot`