### PR TITLE
SITE-1096 fix tests

### DIFF
--- a/inc/cli.php
+++ b/inc/cli.php
@@ -125,22 +125,9 @@ WP_CLI::add_hook( 'before_invoke:elasticpress', function () {
 	}
 
 	if ( ! defined( 'WP_HOME' ) || strpos( WP_HOME, 'http://' ) === 0 ) {
-		add_filter( 'option_home', '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( 'option_home', '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 	if ( ! defined( 'WP_SITEURL' ) || strpos( WP_SITEURL, 'http://' ) === 0 ) {
-		add_filter( 'option_siteurl', '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( 'option_siteurl', '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 } );
-
-/**
- * Replace http:// with https:// in a URL string.
- *
- * @param string $url The option value.
- * @return string The URL with https:// scheme.
- */
-function _pantheon_ep_force_https_url( $url ) {
-	if ( is_string( $url ) && strpos( $url, 'http://' ) === 0 ) {
-		return 'https://' . substr( $url, 7 );
-	}
-	return $url;
-}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -170,3 +170,16 @@ function _pantheon_enqueue_notice_styles() {
 	);
 }
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\_pantheon_enqueue_notice_styles' );
+
+/**
+ * Replace http:// with https:// at the start of a URL string.
+ *
+ * @param mixed $url The option value.
+ * @return mixed The URL with https:// scheme, or the original value if not an http:// string.
+ */
+function _pantheon_ep_force_https_url( $url ) {
+	if ( is_string( $url ) && strpos( $url, 'http://' ) === 0 ) {
+		return 'https://' . substr( $url, 7 );
+	}
+	return $url;
+}

--- a/tests/phpunit/test-elasticpress-cli.php
+++ b/tests/phpunit/test-elasticpress-cli.php
@@ -40,7 +40,7 @@ class Test_ElasticPress_CLI extends WP_UnitTestCase {
 	public function test_force_https_url( $input, $expected ) {
 		$this->assertSame(
 			$expected,
-			\Pantheon\CLI\_pantheon_ep_force_https_url( $input )
+			\Pantheon\_pantheon_ep_force_https_url( $input )
 		);
 	}
 
@@ -74,9 +74,9 @@ class Test_ElasticPress_CLI extends WP_UnitTestCase {
 	 */
 	public function test_option_filter_forces_https( $option ) {
 		$filter_name = 'option_' . $option;
-		add_filter( $filter_name, '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		add_filter( $filter_name, '\\Pantheon\\_pantheon_ep_force_https_url' );
 		update_option( $option, 'http://example.com' );
 		$this->assertEquals( 'https://example.com', get_option( $option ) );
-		remove_filter( $filter_name, '\\Pantheon\\CLI\\_pantheon_ep_force_https_url' );
+		remove_filter( $filter_name, '\\Pantheon\\_pantheon_ep_force_https_url' );
 	}
 }

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -131,7 +131,7 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 		_pantheon_upstream_update_notice();
 		$output = ob_get_clean();
 	
-		$this->assertStringContainsString( 'Check for updates on', $output );
+		$this->assertStringContainsString( 'Check for Updates', $output );
 	}
 	
 	/**
@@ -144,26 +144,26 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 
 		set_current_screen( 'update-core' );
 	
-		// Simulate that the core is not the latest version.
+		// Simulate that the core is not the latest version by using a version higher than any installed WP.
 		set_site_transient(
 			'update_core',
 			(object) [
 				'updates' => [
 					(object) [
-						'current' => '6.3.1',
-						'response' => 'upgrade', 
+						'current' => '99.0.0',
+						'response' => 'upgrade',
 						'locale' => 'en_us',
 					],
 				],
-				'version_checked' => '6.2',
+				'version_checked' => self::$wp_version,
 			],
 		);
-	
+
 		ob_start();
 		_pantheon_upstream_update_notice();
 		$output = ob_get_clean();
-	
-		$this->assertStringContainsString( 'Check for updates on <a href="https://dashboard.pantheon.io/sites/test-site">your Pantheon dashboard</a>', $output );
+
+		$this->assertStringContainsString( 'A new WordPress update is available!', $output );
 	}
 	
 	/**


### PR DESCRIPTION
## Summary

Fixes 14 test failures (12 errors + 2 failures) in the PHPUnit CI run introduced after the notices refactor in #104 and the ElasticPress HTTPS fix in #108.

### ElasticPress CLI test errors (12 errors)

`_pantheon_ep_force_https_url()` was defined in `inc/cli.php` under the `Pantheon\CLI` namespace. That file is only loaded when `WP_CLI` is defined (`pantheon.php:28`), which is not the case in the PHPUnit test environment. This caused all `Test_ElasticPress_CLI` tests to fail with "Call to undefined function."

**Fix:** Moved `_pantheon_ep_force_https_url()` from `inc/cli.php` to `inc/functions.php` (namespace changes from `Pantheon\CLI` to `Pantheon`). The function is a pure string utility with no WP-CLI dependency — it only lived in `cli.php` by proximity to where it was called. `inc/functions.php` is always loaded via the bootstrap, so the function is now available in all contexts. Updated the filter callback references in `cli.php` and the test file accordingly.

### Pantheon Updates test failures (2 failures)

Two issues in `test-pantheon-updates.php`:

1. **Stale assertions:** The notices refactor in #104 replaced inline text (`"Check for updates on <a href=...>your Pantheon dashboard</a>"`) with `_pantheon_render_notice()` which uses structured headings and buttons. The test assertions still checked for the old inline text. Updated to match the current notice output (`"Check for Updates"` heading and `"A new WordPress update is available!"` heading).

2. **Outdated mock version:** `test_pantheon_upstream_update_notice_core_not_latest` mocked `'6.3.1'` as the "latest" available version. `_pantheon_is_wordpress_core_latest()` compares that against the *actually installed* WordPress version (now 6.9.4), so `6.3.1 <= 6.9.4` always returned true — the "update available" branch was never triggered. Changed mock to `'99.0.0'` so the test is not coupled to the installed WordPress version.

## Test plan

- [x] `composer lint` passes
- [x] `composer phpunit` passes locally (59 tests, 0 errors, 0 failures)
- [x] CI passes across PHP 7.4, 8.1, 8.3, 8.4