### PR TITLE
ci: [SITE-5201] Add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         image: mariadb:10.6
     strategy:
       matrix:
-        php_version: [7.4, 8.1, 8.3, 8.4] # Versions represent newest 7.x, WP supported with exclusions, and beta support.
+        php_version: [7.4, 8.1, 8.3, 8.4, 8.5] # Versions represent newest 7.x, WP supported with exclusions, and beta support.
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP


### PR DESCRIPTION
## Summary

- Add PHP 8.5 to the PHPUnit test matrix

## Context

[SITE-5201](https://getpantheon.atlassian.net/browse/SITE-5201)

PHP 8.5 compatibility verification for pantheon-mu-plugin. Local PHPCompatibility scan (8.3-) and PHP 8.5 lint on all 44 source files showed zero issues. No code changes required.

## Test plan

- [x] CI passes on all PHP versions in matrix (7.4, 8.1, 8.3, 8.4, 8.5)
- [x] PHPCompatibility check passes

[SITE-5201]: https://getpantheon.atlassian.net/browse/SITE-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ