### PR TITLE
[SITE-5793] Fix script injection in lint and release workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
             fi
         - name: Commit changes to PR
           if: ${{ env.cbf == 'true' }}
+          env:
+            PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           run: |
             git config --global user.email "bot@getpantheon.com"
             git config --global user.name "Pantheon Robot"
@@ -29,7 +31,7 @@ jobs:
               CHANGES_DETECTED=true
               git add *.php
               git commit -m "PHPCBF: Fix coding standards" --no-verify
-              git push origin ${{ github.event.pull_request.head.ref }} || CHANGES_DETECTED=false
+              git push origin "$PR_BRANCH" || CHANGES_DETECTED=false
               echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_ENV
             else
               echo "changes_detected=false" >> $GITHUB_ENV
@@ -38,9 +40,10 @@ jobs:
           if: ${{ env.changes_detected == 'true' }}
           env:
             GH_TOKEN: ${{ github.token }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
           run: |
             CURRENT_COMMIT=$(git rev-parse --short HEAD)
-            gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly Pantheon Robot! :robot: I fixed PHPCS issues with \`phpcbf\` on $CURRENT_COMMIT. Please review the changes."
+            gh pr comment "$PR_NUMBER" -b "Hi from your friendly Pantheon Robot! :robot: I fixed PHPCS issues with \`phpcbf\` on $CURRENT_COMMIT. Please review the changes."
     lint:
         name: Lint
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,9 @@ jobs:
 
       - name: Check whether this is a release version
         id: check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ "$VERSION" == *-dev ]]; then
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION ends in -dev — skipping release."
@@ -50,15 +51,17 @@ jobs:
 
       - name: Create Git tag
         if: steps.check.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           git tag "$VERSION"
           git push origin "$VERSION"
 
       - name: Create GitHub Release
         if: steps.check.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           gh release create "$VERSION" \
             --generate-notes \
             --title "$VERSION"
@@ -68,8 +71,9 @@ jobs:
       - name: Compute next dev version
         if: steps.check.outputs.is_release == 'true'
         id: next
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
           NEXT_PATCH=$(( PATCH + 1 ))
           NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-dev"
@@ -78,15 +82,17 @@ jobs:
 
       - name: Bump version in pantheon.php
         if: steps.check.outputs.is_release == 'true'
+        env:
+          NEXT: ${{ steps.next.outputs.next_version }}
         run: |
-          NEXT="${{ steps.next.outputs.next_version }}"
           sed -i "s/^\( \* Version: \).*/\1${NEXT}/" pantheon.php
           sed -i "s/\(define( 'PANTHEON_MU_PLUGIN_VERSION', '\)[^']*\(.*\)/\1${NEXT}\2/" pantheon.php
 
       - name: Verify both version strings were updated
         if: steps.check.outputs.is_release == 'true'
+        env:
+          NEXT: ${{ steps.next.outputs.next_version }}
         run: |
-          NEXT="${{ steps.next.outputs.next_version }}"
           COUNT=$(grep -c "$NEXT" pantheon.php)
           if [ "$COUNT" -lt 2 ]; then
             echo "ERROR: Expected at least 2 occurrences of $NEXT in pantheon.php, found $COUNT"
@@ -98,8 +104,9 @@ jobs:
 
       - name: Open version bump PR
         if: steps.check.outputs.is_release == 'true'
+        env:
+          NEXT: ${{ steps.next.outputs.next_version }}
         run: |
-          NEXT="${{ steps.next.outputs.next_version }}"
           BRANCH="chore/bump-version-${NEXT}"
           git checkout -b "$BRANCH"
           git add pantheon.php


### PR DESCRIPTION
## Summary

- Move `${{ github.event.pull_request.head.ref }}` and `${{ github.event.pull_request.number }}` from `run:` blocks to `env:` blocks in lint.yml
- Move `${{ steps.version.outputs.version }}` and `${{ steps.next.outputs.next_version }}` from `run:` blocks to `env:` blocks in release.yml

## Why

Using `${{ }}` expressions directly inside `run:` blocks is a script injection vulnerability. In lint.yml, the workflow triggers on `pull_request` (fork-accessible) and has `contents: write` permissions. A fork PR with a crafted branch name could inject arbitrary shell commands into the CI runner.

The secure pattern is to pass values through `env:` blocks, where they become shell variables instead of being interpolated into the script before shell parsing.

## Test plan

- [ ] Open a PR and verify the lint workflow still runs PHPCBF and commits fixes
- [ ] Verify the release workflow still tags, creates releases, and opens version bump PRs on push to main