### PR TITLE
feat(updates): [SITE-5883] Add dismiss option to WordPress update notice

### DIFF
--- a/inc/assets/js/pantheon-update-notice-dismiss.js
+++ b/inc/assets/js/pantheon-update-notice-dismiss.js
@@ -1,0 +1,31 @@
+/**
+ * Persist dismissal of the Pantheon update notice.
+ *
+ * WordPress's native `is-dismissible` handler only hides the notice in the DOM;
+ * it makes no server call, so the notice returns on the next page load. This
+ * listens for the same dismiss click and records it server-side (per user, keyed
+ * to the current WordPress version) so the notice stays dismissed until a newer
+ * version is available.
+ */
+( function () {
+	document.addEventListener( 'click', function ( event ) {
+		var button = event.target.closest( '.notice-dismiss' );
+		if ( ! button ) {
+			return;
+		}
+
+		if ( ! button.closest( '#pantheon-update-notice' ) ) {
+			return;
+		}
+
+		var data = new FormData();
+		data.append( 'action', pantheonUpdateNotice.action );
+		data.append( 'nonce', pantheonUpdateNotice.nonce );
+
+		fetch( pantheonUpdateNotice.ajaxUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: data,
+		} );
+	} );
+}() );

--- a/inc/assets/js/pantheon-update-notice-dismiss.js
+++ b/inc/assets/js/pantheon-update-notice-dismiss.js
@@ -7,6 +7,7 @@
  * to the current WordPress version) so the notice stays dismissed until a newer
  * version is available.
  */
+/* global pantheonUpdateNotice */
 ( function () {
 	document.addEventListener( 'click', function ( event ) {
 		var button = event.target.closest( '.notice-dismiss' );

--- a/inc/pantheon-updates.php
+++ b/inc/pantheon-updates.php
@@ -5,6 +5,15 @@
  * Handles modifying the default WordPress update behavior on Pantheon.
  */
 
+/*
+ * User-meta key storing the WordPress version a user dismissed the update notice for.
+ * A newer available version no longer matches the stored value, so the notice returns.
+ */
+const PANTHEON_UPDATE_NOTICE_DISMISSED_META = 'pantheon_dismissed_update_notice';
+
+// AJAX action + nonce used by the dismiss handler and its front-end script.
+const PANTHEON_UPDATE_NOTICE_DISMISS_ACTION = 'pantheon_dismiss_update_notice';
+
 // If on Pantheon...
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	// Disable WordPress auto updates.
@@ -108,6 +117,13 @@ function _pantheon_upstream_update_notice() {
 
 	// If core update is available, show the update notice on ALL pages.
 	if ( $core_update_available ) {
+		// Skip the notice if this user already dismissed it for the current available version.
+		$available_version = _pantheon_get_latest_wordpress_version();
+		$dismissed_version = get_user_meta( get_current_user_id(), PANTHEON_UPDATE_NOTICE_DISMISSED_META, true );
+		if ( $available_version && $dismissed_version === $available_version ) {
+			return;
+		}
+
 		$message = sprintf(
 			// translators: %s is a link to the Pantheon upstream updates documentation.
 			__( 'For details on applying updates, see the <a href="%s">Applying Upstream Updates</a> documentation. If you need help, contact an administrator for your Pantheon organization.', 'pantheon-systems' ),
@@ -122,6 +138,7 @@ function _pantheon_upstream_update_notice() {
 			'button_url'    => $dashboard_url,
 			'id'            => 'pantheon-update-notice',
 			'extra_classes' => 'pantheon-update-notice',
+			'dismissible'   => true,
 		] );
 	} elseif ( $is_update_page ) {
 		// If no update is available but we're on the update pages, show the "Check for updates" message.
@@ -182,6 +199,56 @@ function _pantheon_register_upstream_update_notice() {
 	}
 }
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
+
+/**
+ * AJAX handler: record that the current user dismissed the update notice for the
+ * current available WordPress version. The version is resolved server-side so the
+ * client cannot influence which version the dismissal applies to.
+ *
+ * @return void
+ */
+function _pantheon_dismiss_update_notice() {
+	check_ajax_referer( PANTHEON_UPDATE_NOTICE_DISMISS_ACTION, 'nonce' );
+
+	if ( ! is_user_logged_in() ) {
+		wp_send_json_error( 'not_logged_in', 403 );
+	}
+
+	$available_version = _pantheon_get_latest_wordpress_version();
+	if ( ! $available_version ) {
+		wp_send_json_error( 'no_available_version' );
+	}
+
+	update_user_meta( get_current_user_id(), PANTHEON_UPDATE_NOTICE_DISMISSED_META, $available_version );
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_' . PANTHEON_UPDATE_NOTICE_DISMISS_ACTION, '_pantheon_dismiss_update_notice' );
+
+/**
+ * Enqueue the dismiss script and pass it the AJAX URL, action, and nonce.
+ *
+ * @return void
+ */
+function _pantheon_enqueue_update_notice_dismiss() {
+	wp_enqueue_script(
+		'pantheon-update-notice-dismiss',
+		plugin_dir_url( __FILE__ ) . 'assets/js/pantheon-update-notice-dismiss.js',
+		[],
+		PANTHEON_MU_PLUGIN_VERSION,
+		true
+	);
+
+	wp_localize_script(
+		'pantheon-update-notice-dismiss',
+		'pantheonUpdateNotice',
+		[
+			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			'action'  => PANTHEON_UPDATE_NOTICE_DISMISS_ACTION,
+			'nonce'   => wp_create_nonce( PANTHEON_UPDATE_NOTICE_DISMISS_ACTION ),
+		]
+	);
+}
+add_action( 'admin_enqueue_scripts', '_pantheon_enqueue_update_notice_dismiss' );
 
 /**
  * Return zero updates and current time as last checked time.

--- a/tests/e2e/features/hide-update-notice.feature
+++ b/tests/e2e/features/hide-update-notice.feature
@@ -35,8 +35,7 @@ Feature: Hide the Pantheon WordPress update notice
   Scenario: The update notice renders as dismissible
     Given a WordPress core update is available
     When I open the WordPress admin page "/wp-admin/index.php"
-    Then the element "#pantheon-update-notice.is-dismissible" should be visible
-    And the element "#pantheon-update-notice .notice-dismiss" should be visible
+    Then the update notice should offer a dismiss option
 
   Scenario: Dismissing the update notice persists across page loads
     Given a WordPress core update is available
@@ -48,10 +47,7 @@ Feature: Hide the Pantheon WordPress update notice
 
   Scenario: The dismissed notice returns when a newer version is available
     Given a WordPress core update is available
-    When I open the WordPress admin page "/wp-admin/index.php"
-    And I dismiss the update notice
-    And I open the WordPress admin page "/wp-admin/index.php"
-    Then the element "#pantheon-update-notice" should be hidden
+    And the update notice has been dismissed for the current version
     When a newer WordPress core update is released
     And I open the WordPress admin page "/wp-admin/index.php"
     Then the element "#pantheon-update-notice" should be visible

--- a/tests/e2e/features/hide-update-notice.feature
+++ b/tests/e2e/features/hide-update-notice.feature
@@ -31,3 +31,27 @@ Feature: Hide the Pantheon WordPress update notice
     When the PANTHEON_SHOW_UPDATE_NOTICE constant is set to false
     And I open the WordPress admin page "/wp-admin/update-core.php"
     Then the element "#pantheon-update-notice" should be hidden
+
+  Scenario: The update notice renders as dismissible
+    Given a WordPress core update is available
+    When I open the WordPress admin page "/wp-admin/index.php"
+    Then the element "#pantheon-update-notice.is-dismissible" should be visible
+    And the element "#pantheon-update-notice .notice-dismiss" should be visible
+
+  Scenario: Dismissing the update notice persists across page loads
+    Given a WordPress core update is available
+    When I open the WordPress admin page "/wp-admin/index.php"
+    Then the element "#pantheon-update-notice" should be visible
+    When I dismiss the update notice
+    And I open the WordPress admin page "/wp-admin/index.php"
+    Then the element "#pantheon-update-notice" should be hidden
+
+  Scenario: The dismissed notice returns when a newer version is available
+    Given a WordPress core update is available
+    When I open the WordPress admin page "/wp-admin/index.php"
+    And I dismiss the update notice
+    And I open the WordPress admin page "/wp-admin/index.php"
+    Then the element "#pantheon-update-notice" should be hidden
+    When a newer WordPress core update is released
+    And I open the WordPress admin page "/wp-admin/index.php"
+    Then the element "#pantheon-update-notice" should be visible

--- a/tests/e2e/lib/pantheon.ts
+++ b/tests/e2e/lib/pantheon.ts
@@ -91,6 +91,19 @@ if ( get_option( 'e2e_hide_via_filter' ) ) {
 if ( get_option( 'e2e_hide_via_constant' ) && ! defined( 'PANTHEON_SHOW_UPDATE_NOTICE' ) ) {
 \tdefine( 'PANTHEON_SHOW_UPDATE_NOTICE', false );
 }
+if ( get_option( 'e2e_force_update_available' ) ) {
+\tadd_filter( 'site_transient_update_core', function ( $value ) {
+\t\t$forced = get_option( 'e2e_forced_version' );
+\t\t$forced = $forced ? $forced : '99.0.0';
+\t\treturn (object) [
+\t\t\t'updates' => [
+\t\t\t\t(object) [ 'current' => $forced, 'response' => 'upgrade', 'locale' => 'en_US' ],
+\t\t\t],
+\t\t\t'version_checked' => get_bloginfo( 'version' ),
+\t\t\t'last_checked' => time(),
+\t\t];
+\t} );
+}
 `;
 
 /** SFTP the branch plugin files + the option-toggle shim onto the env. */
@@ -101,6 +114,7 @@ export function installBranchPlugin(env: string): void {
   sftpBatch(env, [
     `put ${PLUGIN_SRC}/functions.php ${REMOTE_INC}/functions.php`,
     `put ${PLUGIN_SRC}/pantheon-updates.php ${REMOTE_INC}/pantheon-updates.php`,
+    `put ${PLUGIN_SRC}/assets/js/pantheon-update-notice-dismiss.js ${REMOTE_INC}/assets/js/pantheon-update-notice-dismiss.js`,
     `put ${shim} ${MU_DIR}/${SHIM_FILENAME}`,
   ]);
 }

--- a/tests/e2e/lib/pantheon.ts
+++ b/tests/e2e/lib/pantheon.ts
@@ -12,6 +12,14 @@ function assertSafeName(kind: string, value: string): string {
   return value;
 }
 
+/** Validate a WordPress username (login/email) before it reaches a shell command. */
+export function assertSafeWpUser(value: string): string {
+  if (!/^[A-Za-z0-9._@-]+$/.test(value)) {
+    throw new Error(`Unsafe WP_USER: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
 const SITE = assertSafeName('TERMINUS_SITE', process.env.TERMINUS_SITE || 'pantheon-mu-plugin');
 const SOURCE_ENV = assertSafeName('TERMINUS_SOURCE_ENV', process.env.TERMINUS_SOURCE_ENV || 'dev');
 

--- a/tests/e2e/steps/update-notice.steps.ts
+++ b/tests/e2e/steps/update-notice.steps.ts
@@ -39,6 +39,11 @@ Then('the element {string} should be hidden', async ({ page }, selector: string)
   await expect(page.locator(selector)).toBeHidden();
 });
 
+Then('the update notice should offer a dismiss option', async ({ page }) => {
+  await expect(page.locator('#pantheon-update-notice.is-dismissible')).toBeVisible();
+  await expect(page.locator('#pantheon-update-notice .notice-dismiss')).toBeVisible();
+});
+
 When('I apply the CSS {string}', async ({ page }, css: string) => {
   await page.addStyleTag({ content: css });
 });
@@ -57,6 +62,12 @@ Given('a WordPress core update is available', async () => {
   const { multidev } = readState();
   wpOption(multidev, FORCE_OPTION, '1');
   wpOption(multidev, VERSION_OPTION, '99.0.0');
+});
+
+Given('the update notice has been dismissed for the current version', async () => {
+  const { multidev } = readState();
+  const user = assertSafeWpUser(process.env.WP_USER ?? '');
+  wp(multidev, `user meta update ${user} ${DISMISSED_META} 99.0.0`);
 });
 
 When('a newer WordPress core update is released', async () => {

--- a/tests/e2e/steps/update-notice.steps.ts
+++ b/tests/e2e/steps/update-notice.steps.ts
@@ -1,7 +1,7 @@
 import { createBdd } from 'playwright-bdd';
 import { test } from 'playwright-bdd';
 import { expect } from '@playwright/test';
-import { readState, wpOption, wp } from '../lib/pantheon';
+import { readState, wpOption, wp, assertSafeWpUser } from '../lib/pantheon';
 
 const { Given, When, Then, After } = createBdd(test);
 
@@ -85,7 +85,8 @@ After(async () => {
   wpOption(multidev, CONSTANT_OPTION, '0');
   wpOption(multidev, FORCE_OPTION, '0');
   try {
-    wp(multidev, `user meta delete ${process.env.WP_USER} ${DISMISSED_META}`);
+    const user = assertSafeWpUser(process.env.WP_USER ?? '');
+    wp(multidev, `user meta delete ${user} ${DISMISSED_META}`);
   } catch {
     // Meta may not exist if the scenario never dismissed; ignore.
   }

--- a/tests/e2e/steps/update-notice.steps.ts
+++ b/tests/e2e/steps/update-notice.steps.ts
@@ -1,7 +1,7 @@
 import { createBdd } from 'playwright-bdd';
 import { test } from 'playwright-bdd';
 import { expect } from '@playwright/test';
-import { readState, wpOption } from '../lib/pantheon';
+import { readState, wpOption, wp } from '../lib/pantheon';
 
 const { Given, When, Then, After } = createBdd(test);
 
@@ -9,6 +9,11 @@ const { Given, When, Then, After } = createBdd(test);
 // options, so scenarios toggle them with a fast DB write (no per-test deploy).
 const FILTER_OPTION = 'e2e_hide_via_filter';
 const CONSTANT_OPTION = 'e2e_hide_via_constant';
+// The shim also forces a core update to appear (and at which version) so the
+// dismissible update-available notice renders deterministically.
+const FORCE_OPTION = 'e2e_force_update_available';
+const VERSION_OPTION = 'e2e_forced_version';
+const DISMISSED_META = 'pantheon_dismissed_update_notice';
 
 // The Pantheon sandbox interstitial is bypassed via the Deterrence-Bypass HTTP
 // header set in playwright.config.ts (use.extraHTTPHeaders), so no page load
@@ -48,10 +53,40 @@ When('the PANTHEON_SHOW_UPDATE_NOTICE constant is set to false', async () => {
   wpOption(multidev, CONSTANT_OPTION, '1');
 });
 
-// Reset both toggle options after each scenario so scenarios stay isolated on
-// the shared multidev (a DB write, no deploy).
+Given('a WordPress core update is available', async () => {
+  const { multidev } = readState();
+  wpOption(multidev, FORCE_OPTION, '1');
+  wpOption(multidev, VERSION_OPTION, '99.0.0');
+});
+
+When('a newer WordPress core update is released', async () => {
+  const { multidev } = readState();
+  wpOption(multidev, VERSION_OPTION, '100.0.0');
+});
+
+When('I dismiss the update notice', async ({ page }) => {
+  // WordPress hides the notice client-side on click; wait for our AJAX POST so
+  // the dismissal is persisted server-side before the next page load.
+  await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.url().includes('admin-ajax.php') &&
+        (r.request().postData() || '').includes('pantheon_dismiss_update_notice')
+    ),
+    page.locator('#pantheon-update-notice .notice-dismiss').click(),
+  ]);
+});
+
+// Reset toggles + the forced-update state, and clear the per-user dismissal so
+// scenarios stay isolated on the shared multidev (DB writes, no deploy).
 After(async () => {
   const { multidev } = readState();
   wpOption(multidev, FILTER_OPTION, '0');
   wpOption(multidev, CONSTANT_OPTION, '0');
+  wpOption(multidev, FORCE_OPTION, '0');
+  try {
+    wp(multidev, `user meta delete ${process.env.WP_USER} ${DISMISSED_META}`);
+  } catch {
+    // Meta may not exist if the scenario never dismissed; ignore.
+  }
 });

--- a/tests/phpunit/test-pantheon-update-notice-dismiss.php
+++ b/tests/phpunit/test-pantheon-update-notice-dismiss.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Pantheon update-notice dismiss AJAX handler tests.
+ *
+ * @package pantheon
+ */
+
+/**
+ * Tests for the wp_ajax_pantheon_dismiss_update_notice handler.
+ *
+ * @group ajax
+ */
+class Test_Pantheon_Update_Notice_Dismiss extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Simulate that a core update (99.0.0) is available.
+	 */
+	private function simulate_core_update_available() {
+		set_site_transient(
+			'update_core',
+			(object) [
+				'updates' => [
+					(object) [
+						'current'  => '99.0.0',
+						'response' => 'upgrade',
+						'locale'   => 'en_us',
+					],
+				],
+				'version_checked' => get_bloginfo( 'version' ),
+			]
+		);
+	}
+
+	/**
+	 * A valid dismiss request stores the current available version in user meta.
+	 */
+	public function test_dismiss_stores_available_version() {
+		$this->simulate_core_update_available();
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$_POST['nonce'] = wp_create_nonce( PANTHEON_UPDATE_NOTICE_DISMISS_ACTION );
+
+		try {
+			$this->_handleAjax( PANTHEON_UPDATE_NOTICE_DISMISS_ACTION );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// wp_send_json_success() dies; expected in the success path.
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertTrue( $response['success'] );
+		$this->assertEquals( '99.0.0', get_user_meta( $user_id, PANTHEON_UPDATE_NOTICE_DISMISSED_META, true ) );
+	}
+
+	/**
+	 * A request with an invalid nonce is rejected and stores nothing.
+	 */
+	public function test_dismiss_rejects_bad_nonce() {
+		$this->simulate_core_update_available();
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$_POST['nonce'] = 'invalid-nonce';
+
+		try {
+			$this->expectException( WPAjaxDieStopException::class );
+			$this->_handleAjax( PANTHEON_UPDATE_NOTICE_DISMISS_ACTION );
+		} finally {
+			$this->assertEmpty( get_user_meta( $user_id, PANTHEON_UPDATE_NOTICE_DISMISSED_META, true ) );
+		}
+	}
+}

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -315,4 +315,61 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'A new WordPress update is available!', $output );
 	}
+
+	/**
+	 * Test that the update notice carries the is-dismissible class.
+	 */
+	public function test_update_notice_is_dismissible() {
+		if ( $this->is_prerelease() ) {
+			$this->markTestSkipped( 'Prerelease build renders a different notice.' );
+		}
+
+		$this->simulate_core_not_latest();
+
+		ob_start();
+		_pantheon_upstream_update_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'is-dismissible', $output );
+	}
+
+	/**
+	 * Test that the notice is hidden when the user dismissed it for the current available version.
+	 */
+	public function test_update_notice_hidden_when_dismissed_for_current_version() {
+		if ( $this->is_prerelease() ) {
+			$this->markTestSkipped( 'Prerelease build renders a different notice.' );
+		}
+
+		$this->simulate_core_not_latest(); // Available version: 99.0.0.
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, PANTHEON_UPDATE_NOTICE_DISMISSED_META, '99.0.0' );
+
+		ob_start();
+		_pantheon_upstream_update_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that the notice returns when a newer version is available than the one dismissed.
+	 */
+	public function test_update_notice_shows_when_newer_version_available() {
+		if ( $this->is_prerelease() ) {
+			$this->markTestSkipped( 'Prerelease build renders a different notice.' );
+		}
+
+		$this->simulate_core_not_latest(); // Available version: 99.0.0.
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, PANTHEON_UPDATE_NOTICE_DISMISSED_META, '6.0.0' ); // Stale dismissal.
+
+		ob_start();
+		_pantheon_upstream_update_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'A new WordPress update is available!', $output );
+	}
 }

--- a/tests/phpunit/test-pantheon-updates.php
+++ b/tests/phpunit/test-pantheon-updates.php
@@ -275,7 +275,8 @@ class Test_Pantheon_Updates extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'id="pantheon-update-notice"', $output );
-		$this->assertStringContainsString( 'pantheon-notice pantheon-update-notice', $output );
+		// pantheon-update-notice is a class token (order-independent; is-dismissible now sits between it and pantheon-notice).
+		$this->assertMatchesRegularExpression( '/class="[^"]*\bpantheon-update-notice\b/', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Make the "A new WordPress update is available!" notice dismissible. The notice already carried the `is-dismissible` class, but WordPress's native dismiss is client-side only, so the notice returned on the next page load (the GitHub #116 complaint).
- Persist dismissal **per user, keyed to the available WordPress version** via a single user-meta key (`pantheon_dismissed_update_notice`). A newer available version no longer matches the stored value, so the notice returns automatically. No stale-meta cleanup needed (one key, overwritten).
- Add a `wp_ajax_pantheon_dismiss_update_notice` handler (nonce + `update_user_meta`; the target version is resolved server-side, not trusted from the client) and a small script that fires on the native dismiss click.
- Add a render gate to `_pantheon_upstream_update_notice()` that skips the notice when the user's dismissed version equals the current available version.

## Context

[SITE-5883](https://getpantheon.atlassian.net/browse/SITE-5883)

Community feedback (GitHub #116): the update notice is persistent and reappears on every admin page load. Maintainer guidance on that issue confirmed the fix must use user meta keyed to the version (client-side `is-dismissible` alone does not persist).

Builds on SITE-5884 (#119, merged): reuses the `_pantheon_render_notice()` `dismissible` support and the playwright-bdd e2e harness. `_pantheon_render_notice()` and the other `dismissible` callsites (multisite-finalize, page-cache) are intentionally left untouched — persistence is wired only at the update-notice callsite.

## Changes

| File | Change |
|---|---|
| `inc/pantheon-updates.php` | Render gate + `dismissible => true` on the update-available notice; `wp_ajax_pantheon_dismiss_update_notice` handler; enqueue + localize; two shared consts |
| `inc/assets/js/pantheon-update-notice-dismiss.js` | Persists the native dismiss click via an AJAX POST (fire-and-forget) |
| `tests/phpunit/test-pantheon-updates.php` | Gate tests: is-dismissible present, hidden when dismissed for current version, returns when newer version available |
| `tests/phpunit/test-pantheon-update-notice-dismiss.php` | Handler tests: stores available version on valid nonce, rejects bad nonce |
| `tests/e2e/` | 3 BDD scenarios (renders dismissible / persists across reload / reappears on newer version); installer now also deploys the dismiss JS |

## Testing

**Local wp-env (browser, Playwright-driven):**
- [x] Notice renders with the native dismiss X
- [x] Click X → AJAX POST → 200 → dismissal stored in user meta
- [x] Reload → notice stays hidden (the core AC)
- [x] Bump available version → notice returns

**Automated:** phpunit (gate + handler) and BDD (dismiss / persist-across-reload / reappear) run in CI.

## Test plan

- [ ] CI: all PHP legs green (phpunit)
- [ ] CI: BDD e2e green against a provisioned multidev
- [ ] Reviewer sanity-check on multisite / network admin

## Open items

- **Test home:** the BDD harness still lives in this repo. Per Ander, it should move to the public CMS-only test framework once that lands (carried over from #119). Tracked separately.

## References

- Jira: [SITE-5883](https://getpantheon.atlassian.net/browse/SITE-5883)
- GitHub issue: pantheon-systems/pantheon-mu-plugin#116
- Predecessor: pantheon-systems/pantheon-mu-plugin#119 (SITE-5884, merged)


[SITE-5883]: https://getpantheon.atlassian.net/browse/SITE-5883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5883]: https://getpantheon.atlassian.net/browse/SITE-5883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ