### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Generate composer diff
         id: composer_diff
-        uses: IonBazan/composer-diff-action@v1
-      - uses: marocchino/sticky-pull-request-comment@v2
+        uses: IonBazan/composer-diff-action@3140157575f6a67799cc80248ae35f5fb303ab15 # v1
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:
           header: composer-diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - '**'
+permissions:
+  contents: read
 env:
   TERM: xterm-256color
 jobs:
@@ -11,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@dev
         with:
@@ -28,16 +30,16 @@ jobs:
       matrix:
         php_version: [7.4, 8.1, 8.3, 8.4, 8.5] # Versions represent newest 7.x, WP supported with exclusions, and beta support.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php_version }}
           extensions: mysqli, zip, imagick
       - name: Start MySQL
         run: sudo systemctl start mysql
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/vendor
           key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
## Summary

Fixes 6 of the 8 open CodeQL alerts on this repo. The remaining 2 (alerts #3 and #8, for `pantheon-systems/phpcompatibility-action@dev`) are covered by PR #118 (SITE-5793).

**Missing workflow permissions (alerts #1, #2):**
- Added explicit `permissions: contents: read` to `test.yml`. This workflow only checks out code and runs tests; it needs no write access.

**Unpinned action tags (alerts #4, #7) in `test.yml`:**
- Pinned `actions/checkout@v4`, `shivammathur/setup-php@v2`, and `actions/cache@v4` to their current commit SHAs with version comments.

**Unpinned action tags (alerts #5, #6) in `composer-diff.yml`:**
- Pinned `actions/checkout@v4`, `IonBazan/composer-diff-action@v1`, and `marocchino/sticky-pull-request-comment@v2` to their current commit SHAs with version comments.

## Why

SHA pinning prevents supply-chain attacks where a compromised upstream tag could inject malicious code into CI. Explicit permissions follow the principle of least privilege, limiting the blast radius if a workflow is compromised.