### PR TITLE
chore: release 1.5.7

### DIFF
--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.5.7-dev
+ * Version: 1.5.7
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.7-dev' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.5.7' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';


### PR DESCRIPTION
## Summary

Flip the version in `pantheon.php` from `1.5.7-dev` to `1.5.7` to cut the **1.5.7** release. Both version strings updated (plugin header + `PANTHEON_MU_PLUGIN_VERSION` constant).

On merge to `main`, `release.yml` auto-tags `1.5.7`, publishes the GitHub release with generated notes, then bumps to `1.5.8-dev` via an auto-merge PR.

## Included since 1.5.6

- SITE-5884 (#119): CSS hook + `pantheon_show_update_notice` filter + `PANTHEON_SHOW_UPDATE_NOTICE` constant to hide the update notice
- SITE-5883 (#121): dismissible update notice (per-user, persists until a newer version)

## Notes

- No changelog files in this repo; release notes auto-generate from PR titles.
- Distribution: bundled into the `pantheon-systems/WordPress` upstream via Update Tool (pulls latest `main`); not wp.org.
- Docs: documentation#10166 (held) unblocks once 1.5.7 ships.