### PR TITLE
fix(ci): [SITE-5785] Use github-actions[bot] identity for verified commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,8 @@ jobs:
         - name: Commit changes to PR
           if: ${{ env.cbf == 'true' }}
           run: |
-            git config --global user.email "bot@getpantheon.com"
-            git config --global user.name "Pantheon Robot"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
             if ! git diff-index --quiet HEAD --; then
               CHANGES_DETECTED=true
               git add *.php

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Configure git identity
         if: steps.check.outputs.is_release == 'true'
         run: |
-          git config user.email "bot@getpantheon.com"
-          git config user.name "Pantheon Robot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
 
       - name: Create Git tag
         if: steps.check.outputs.is_release == 'true'


### PR DESCRIPTION
## Summary

Switch the automation git identity from `bot@getpantheon.com` / "Pantheon Robot" to `github-actions[bot]` in:

- `release.yml` — the identity used for the release tag and the version-bump PR commit
- `lint.yml` — the identity used for PHPCBF auto-fix commits on PRs

## Why

Org-level rulesets now require verified (signed) commits on SiteX repos. The previous identity produces **unsigned** commits, which branch protection blocks. Commits made by GitHub Actions are auto-signed by GitHub when they use the `github-actions[bot]` noreply email (`41898282+github-actions[bot]@users.noreply.github.com`), so switching to it yields verified commits.

Same change as pantheon-systems/action-package-updater#53, applied to this repo's workflows.

## Test plan

- [ ] Trigger the PHPCBF path (lint.yml) and confirm the auto-fix commit shows as "Verified".
- [ ] On the next release, confirm the tag and version-bump commit show as "Verified".

## References

- Jira: [SITE-5785](https://getpantheon.atlassian.net/browse/SITE-5785)
- Reference PR: pantheon-systems/action-package-updater#53

[SITE-5785]: https://getpantheon.atlassian.net/browse/SITE-5785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ