### PR TITLE
Add pull_request trigger to test and e2e workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   e2e:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     name: Playwright E2E (Pantheon multidev)
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'tests/e2e/**'
+      - '.github/workflows/e2e.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ name: E2E
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
 permissions:
   contents: read
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,8 @@ name: Test
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
-    branches:
-      - '**'
 permissions:
   contents: read
 env:


### PR DESCRIPTION
## Summary

- test.yml and e2e.yml only triggered on `push` (all branches), meaning tests ran after merge but not on PRs
- Narrowed `push` to `main` only, added `pull_request` trigger so tests run before merge
- `push` is restricted to `main` to avoid duplicate CI runs: without this, pushing to a PR branch fires both `push` and `pull_request` events simultaneously, running the same tests twice
- e2e.yml keeps the same path filter for both push and pull_request
- e2e.yml skips fork PRs (secrets not available, workflow would fail at Terminus auth)

## Why

Ensure tests run on PRs so failures are caught before merge. This also mitigates the GitHub 60-day inactivity issue: if nightly CI gets silently disabled on a quiet repo, PR-triggered tests still catch problems before they land on main.

Part of [SITE-6011](https://getpantheon.atlassian.net/browse/SITE-6011).

[SITE-6011]: https://getpantheon.atlassian.net/browse/SITE-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ